### PR TITLE
fix(api): Use opaque stytch_member_id in member endpoints

### DIFF
--- a/backend/tests/accounts/test_api.py
+++ b/backend/tests/accounts/test_api.py
@@ -1271,13 +1271,15 @@ class TestUpdateMemberRole:
 
         mock_client = MagicMock()
 
-        request = request_factory.patch(f"/api/v1/auth/organization/members/{target_member.id}")
+        request = request_factory.patch(
+            f"/api/v1/auth/organization/members/{target_member.stytch_member_id}"
+        )
         request.auth = AuthContext(user=admin_user, member=admin_member, organization=org)
 
         payload = UpdateMemberRoleRequest(role="admin")
 
         with patch("apps.accounts.stytch_client.get_stytch_client", return_value=mock_client):
-            result = update_member_role_endpoint(request, target_member.id, payload)
+            result = update_member_role_endpoint(request, target_member.stytch_member_id, payload)
 
         assert "admin" in result.message
         target_member.refresh_from_db()
@@ -1289,13 +1291,15 @@ class TestUpdateMemberRole:
         user = UserFactory()
         member = MemberFactory(user=user, organization=org, role="admin")
 
-        request = request_factory.patch(f"/api/v1/auth/organization/members/{member.id}")
+        request = request_factory.patch(
+            f"/api/v1/auth/organization/members/{member.stytch_member_id}"
+        )
         request.auth = AuthContext(user=user, member=member, organization=org)
 
         payload = UpdateMemberRoleRequest(role="member")
 
         with pytest.raises(HttpError) as exc_info:
-            update_member_role_endpoint(request, member.id, payload)
+            update_member_role_endpoint(request, member.stytch_member_id, payload)
 
         assert exc_info.value.status_code == 400
         assert "own role" in str(exc_info.value.message).lower()
@@ -1307,13 +1311,15 @@ class TestUpdateMemberRole:
         member = MemberFactory(user=user, organization=org, role="member")
         target_member = MemberFactory(organization=org, role="member")
 
-        request = request_factory.patch(f"/api/v1/auth/organization/members/{target_member.id}")
+        request = request_factory.patch(
+            f"/api/v1/auth/organization/members/{target_member.stytch_member_id}"
+        )
         request.auth = AuthContext(user=user, member=member, organization=org)
 
         payload = UpdateMemberRoleRequest(role="admin")
 
         with pytest.raises(HttpError) as exc_info:
-            update_member_role_endpoint(request, target_member.id, payload)
+            update_member_role_endpoint(request, target_member.stytch_member_id, payload)
 
         assert exc_info.value.status_code == 403
 
@@ -1332,11 +1338,13 @@ class TestDeleteMember:
 
         mock_client = MagicMock()
 
-        request = request_factory.delete(f"/api/v1/auth/organization/members/{target_member.id}")
+        request = request_factory.delete(
+            f"/api/v1/auth/organization/members/{target_member.stytch_member_id}"
+        )
         request.auth = AuthContext(user=admin_user, member=admin_member, organization=org)
 
         with patch("apps.accounts.stytch_client.get_stytch_client", return_value=mock_client):
-            result = delete_member_endpoint(request, target_member.id)
+            result = delete_member_endpoint(request, target_member.stytch_member_id)
 
         assert "target@example.com" in result.message
         target_member.refresh_from_db()
@@ -1348,11 +1356,13 @@ class TestDeleteMember:
         user = UserFactory()
         member = MemberFactory(user=user, organization=org, role="admin")
 
-        request = request_factory.delete(f"/api/v1/auth/organization/members/{member.id}")
+        request = request_factory.delete(
+            f"/api/v1/auth/organization/members/{member.stytch_member_id}"
+        )
         request.auth = AuthContext(user=user, member=member, organization=org)
 
         with pytest.raises(HttpError) as exc_info:
-            delete_member_endpoint(request, member.id)
+            delete_member_endpoint(request, member.stytch_member_id)
 
         assert exc_info.value.status_code == 400
         assert "yourself" in str(exc_info.value.message).lower()
@@ -1364,11 +1374,13 @@ class TestDeleteMember:
         member = MemberFactory(user=user, organization=org, role="member")
         target_member = MemberFactory(organization=org, role="member")
 
-        request = request_factory.delete(f"/api/v1/auth/organization/members/{target_member.id}")
+        request = request_factory.delete(
+            f"/api/v1/auth/organization/members/{target_member.stytch_member_id}"
+        )
         request.auth = AuthContext(user=user, member=member, organization=org)
 
         with pytest.raises(HttpError) as exc_info:
-            delete_member_endpoint(request, target_member.id)
+            delete_member_endpoint(request, target_member.stytch_member_id)
 
         assert exc_info.value.status_code == 403
 


### PR DESCRIPTION
## Summary

- Replace sequential integer IDs with opaque Stytch member IDs in member management endpoints
- Prevent enumeration attacks by using non-predictable identifiers

## Problem

Member endpoints used sequential integer IDs (`/organization/members/1`, `/organization/members/2`, etc.) which:
- Enable enumeration attacks (guessing other member IDs)
- Leak information about membership existence
- Violate OWASP guidelines for predictable identifiers

## Solution

Use the existing `stytch_member_id` field (format: `member-xxx`) as the public identifier:
- Already unique and indexed in the database
- Opaque, non-guessable format
- Consistent with Stytch's external API

### Endpoints Changed

| Endpoint | Before | After |
|----------|--------|-------|
| `PATCH /organization/members/{id}` | `/members/123` | `/members/member-abc123` |
| `DELETE /organization/members/{id}` | `/members/123` | `/members/member-abc123` |

### Other Models Reviewed

| Model | Status | Notes |
|-------|--------|-------|
| UploadedImage | ✓ Safe | Uses UUID primary key |
| WebhookEndpoint | ✓ Safe | Uses prefixed string ID (wh_xxx) |
| Passkey | Low risk | User can only access own passkeys |

## Test plan

- [x] Run member management tests: `uv run pytest tests/accounts/test_api.py::TestUpdateMemberRole tests/accounts/test_api.py::TestDeleteMember -v`
- [x] Run full accounts test suite: `uv run pytest tests/accounts/ -v`
- [ ] Verify API clients use `stytch_member_id` from member list response

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Replaces sequential integer IDs with opaque Stytch member IDs (`member-xxx` format) in two member management endpoints: update role and delete member. This prevents enumeration attacks where attackers could iterate through predictable IDs to discover organization members.

**Key Changes:**
- Changed `member_id` parameter type from `int` to `str` in both endpoints
- Updated database queries to filter by `stytch_member_id` instead of `id`
- Updated self-comparison checks to use `stytch_member_id` 
- Added documentation clarifying the expected ID format
- All tests updated to use `stytch_member_id` field from test fixtures

**Security Impact:**
The `stytch_member_id` field is already unique and indexed in the Member model (models.py:120-125), making this change both safe and efficient. Organization scoping is properly maintained in all queries (`stytch_member_id=member_id, organization=org`), preventing cross-organization access.

<h3>Confidence Score: 5/5</h3>


- Safe to merge with no concerns - well-executed security improvement
- The implementation correctly addresses the enumeration vulnerability without introducing any new issues. The `stytch_member_id` field is already indexed and unique, queries maintain proper organization scoping, and comprehensive test coverage validates all scenarios including error cases.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| backend/apps/accounts/api.py | Changed member endpoints to use opaque `stytch_member_id` strings instead of sequential integer IDs. Properly maintains organization scoping in queries. Security improvement with no logic issues. |
| backend/tests/accounts/test_api.py | Updated all test cases to use `stytch_member_id` instead of integer IDs. Tests cover success cases and error conditions comprehensively. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Member API
    participant DB as Database
    participant Stytch
    
    Note over Client,Stytch: Update Member Role Flow
    Client->>API: PATCH /organization/members/{stytch_member_id}
    API->>DB: Query Member by stytch_member_id + org
    DB-->>API: Return target_member
    API->>API: Validate not changing own role
    API->>Stytch: Update member role
    Stytch-->>API: Success
    API->>DB: Update member.role
    API->>API: Publish member.role_changed event
    API-->>Client: 200 OK
    
    Note over Client,Stytch: Delete Member Flow
    Client->>API: DELETE /organization/members/{stytch_member_id}
    API->>DB: Query Member by stytch_member_id + org
    DB-->>API: Return target_member
    API->>API: Validate not removing yourself
    API->>Stytch: Delete member
    Stytch-->>API: Success
    API->>DB: Soft delete (set deleted_at)
    API->>API: Publish member.removed event
    API-->>Client: 200 OK
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->