### PR TITLE
perf(api): Use database-level pagination for member list

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -847,14 +847,7 @@ def list_members(
         limit: Maximum records to return (default None = all)
     """
     _, _, org = get_auth_context(request)
-    all_members = list_organization_members(org)
-    total = len(all_members)
-
-    # Apply pagination
-    if limit is not None:
-        members = all_members[offset : offset + limit]
-    else:
-        members = all_members[offset:] if offset > 0 else all_members
+    members, total = list_organization_members(org, offset=offset, limit=limit)
 
     # Fetch member statuses from Stytch
     stytch = get_stytch_client()


### PR DESCRIPTION
## Summary

- Fix memory inefficiency in member list endpoint
- Use database-level pagination instead of Python slicing

## Problem

The member list endpoint loaded all members into memory before applying pagination:

```python
all_members = list_organization_members(org)  # Fetches ALL records
total = len(all_members)
members = all_members[offset:offset + limit]  # Slices in Python
```

For organizations with thousands of members, this causes:
- High memory usage
- Slow response times
- Potential OOM errors

## Solution

Use database-level pagination with queryset slicing:

```python
members, total = list_organization_members(org, offset=offset, limit=limit)
# Internally uses:
# - queryset.count() for total
# - queryset[offset:offset+limit] for records
```

### API Changes

- `list_organization_members(org)` → `list_organization_members(org, offset=0, limit=None)`
- Now returns `tuple[list[Member], int]` instead of `list[Member]`

## Test plan

- [x] Run pagination tests: `uv run pytest tests/accounts/test_services.py::TestListOrganizationMembers -v`
- [x] Run API tests: `uv run pytest tests/accounts/test_api.py::TestListMembers -v`
- [x] Run full accounts test suite: `uv run pytest tests/accounts/ -v`
- [ ] Test with large organization (1000+ members) to verify memory improvement

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Refactored member list endpoint to use database-level pagination instead of loading all records into memory, significantly improving performance for large organizations.

- Modified `list_organization_members` to accept `offset` and `limit` parameters and return a tuple of `(members, total)`
- Uses `queryset.count()` for total and `queryset[offset:offset+limit]` for efficient DB-level slicing
- Updated API endpoint to use the new service signature
- Added comprehensive test coverage for pagination edge cases

**Note:** The Stytch API call on line 856 still fetches all members regardless of pagination parameters, which partially undermines the performance gains. Consider paginating this call or fetching statuses only for the returned member IDs.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with moderate risk
- The database pagination implementation is solid with excellent test coverage. However, the Stytch API call still fetches all members, which partially limits the performance benefits for very large organizations. All call sites were properly updated and backward compatibility is maintained.
- Pay attention to `backend/apps/accounts/api.py` - the Stytch API call may need future optimization

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| backend/apps/accounts/services.py | Implemented database-level pagination with queryset slicing and count, properly handling offset and limit parameters |
| backend/apps/accounts/api.py | Updated to use new tuple return type from list_organization_members; Stytch API call still fetches all members regardless of pagination |
| backend/tests/accounts/test_services.py | Comprehensive test coverage including pagination edge cases (offset, limit, combined), all tests properly updated for new tuple return type |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as list_members API
    participant Service as list_organization_members
    participant DB as Database
    participant Stytch as Stytch API

    Client->>API: GET /members?offset=0&limit=10
    API->>Service: list_organization_members(org, offset=0, limit=10)
    Service->>DB: queryset.count()
    DB-->>Service: total count
    Service->>DB: queryset[0:10] (DB-level slice)
    DB-->>Service: 10 member records
    Service-->>API: (members, total)
    API->>Stytch: organizations.members.search(org_id)
    Stytch-->>API: ALL member statuses
    API->>API: Build response with statuses
    API-->>Client: {members: [...], total, offset, limit}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->