### PR TITLE
fix(frontend): handle 204 No Content responses in API client

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -53,8 +53,8 @@ export function createApiClient(getToken: TokenProvider) {
       throw new Error(error.detail)
     }
 
-    // Handle 204 No Content responses (e.g., DELETE endpoints)
-    if (response.status === 204) {
+    // Handle empty-body responses (204 No Content, 205 Reset Content)
+    if (response.status === 204 || response.status === 205) {
       return undefined as T
     }
 


### PR DESCRIPTION
## Summary
- Add early return for 204 status in the API client's `request` helper

## Problem
The `request` helper in `client.ts` always called `response.json()`, which throws a `SyntaxError` on empty-body responses like 204 No Content (common for DELETE endpoints).

## Solution
Check for `response.status === 204` before attempting to parse JSON, returning `undefined` instead.

## Test plan
- [ ] Call a DELETE endpoint that returns 204 and verify no error is thrown
- [ ] Verify regular JSON responses still work correctly

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added early return for 204 No Content responses to prevent `SyntaxError` when calling `response.json()` on empty response bodies. This fix resolves crashes when calling DELETE endpoints that return 204 status codes.

- Fixed the bug where DELETE endpoints returning 204 would throw parsing errors
- Returns `undefined` for 204 responses instead of attempting JSON parsing
- Maintains correct behavior for all other response types

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The fix correctly addresses the 204 No Content issue with a simple, focused solution. The implementation is sound and follows best practices. Minor consideration: other empty-body status codes could potentially cause similar issues in the future
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/src/api/client.ts | Added 204 No Content handling to prevent JSON parsing errors on empty responses |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Frontend Client
    participant API as API Client
    participant Server as Backend Server

    Client->>API: delete(endpoint)
    API->>API: request(endpoint, {method: 'DELETE'})
    API->>API: getToken()
    API->>Server: fetch() with DELETE method
    Server-->>API: 204 No Content (empty body)
    API->>API: Check response.ok
    API->>API: Check status === 204
    API-->>Client: return undefined
    
    Note over API: Before fix: would call response.json()<br/>causing SyntaxError on empty body
    Note over API: After fix: returns undefined<br/>for 204 status
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->