### PR TITLE
feat(auth): add Google One Tap support for faster sign-in

### DIFF
--- a/frontend/src/features/auth/hooks/use-google-one-tap.ts
+++ b/frontend/src/features/auth/hooks/use-google-one-tap.ts
@@ -1,0 +1,80 @@
+import { useStytchB2BClient } from '@stytch/react/b2b'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface OneTapState {
+  isAvailable: boolean
+  isLoading: boolean
+  error: string | null
+  didRender: boolean
+  notRenderedReason: string | null
+}
+
+interface UseGoogleOneTapOptions {
+  /** Auto-show One Tap on mount. Defaults to true. */
+  autoShow?: boolean
+  /** Redirect URL after One Tap auth. Defaults to /auth/callback */
+  redirectUrl?: string
+}
+
+interface UseGoogleOneTapReturn {
+  state: OneTapState
+  showOneTap: () => Promise<void>
+}
+
+/**
+ * Hook for Google One Tap authentication in discovery flow.
+ *
+ * Shows the browser-native Google prompt in the top-right corner.
+ * Falls back gracefully if One Tap can't render (e.g., user dismissed it,
+ * third-party cookies blocked, etc.)
+ */
+export function useGoogleOneTap(options: UseGoogleOneTapOptions = {}): UseGoogleOneTapReturn {
+  const { autoShow = true, redirectUrl } = options
+  const stytch = useStytchB2BClient()
+  const hasAutoShown = useRef(false)
+
+  const [state, setState] = useState<OneTapState>({
+    isAvailable: true,
+    isLoading: false,
+    error: null,
+    didRender: false,
+    notRenderedReason: null,
+  })
+
+  const showOneTap = useCallback(async () => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }))
+
+    try {
+      const result = await stytch.oauth.googleOneTap.discovery.start({
+        discovery_redirect_url: redirectUrl ?? `${window.location.origin}/auth/callback`,
+      })
+
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        didRender: result.isPromptDisplayed,
+        notRenderedReason: result.isPromptDisplayed ? null : (result.reason ?? 'Unknown reason'),
+        isAvailable: result.isPromptDisplayed,
+      }))
+    } catch (err) {
+      // One Tap not available (e.g., not configured, test environment)
+      const message = err instanceof Error ? err.message : 'Google One Tap not available'
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        isAvailable: false,
+        error: message,
+      }))
+    }
+  }, [stytch, redirectUrl])
+
+  // Auto-show on mount if enabled
+  useEffect(() => {
+    if (autoShow && !hasAutoShown.current) {
+      hasAutoShown.current = true
+      void showOneTap()
+    }
+  }, [autoShow, showOneTap])
+
+  return { state, showOneTap }
+}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -11,6 +11,7 @@ import { GoogleOAuthButton } from '@/features/auth/components/google-oauth-butto
 import { OrganizationSelector } from '@/features/auth/components/organization-selector'
 import { PasskeyLoginButton } from '@/features/auth/components/passkey-login-button'
 import { useDiscoveryAuth } from '@/features/auth/hooks/use-discovery-auth'
+import { useGoogleOneTap } from '@/features/auth/hooks/use-google-one-tap'
 import { hasPasskeyHint, isWebAuthnSupported } from '@/features/auth/hooks/use-passkey-auth'
 
 // Passkey placeholder token before Stytch session attestation
@@ -126,6 +127,11 @@ export default function Login() {
   const { session, isInitialized } = useStytchMemberSession()
   const { state, sendMagicLink, startGoogleOAuth, exchangeSession, resetToEmail } =
     useDiscoveryAuth()
+
+  // Try to show Google One Tap prompt on page load
+  // If successful, it redirects to /auth/callback like regular OAuth
+  // If it can't render (dismissed, blocked, etc.), user uses regular login UI
+  useGoogleOneTap({ autoShow: true })
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- isInitialized can be false


### PR DESCRIPTION
## Summary

- Add browser-native Google One Tap prompt on the login page
- Returning users can sign in with a single click without leaving the page
- The prompt appears automatically in the top-right corner of the browser
- Falls back gracefully to regular OAuth button if One Tap can't render

## Changes

- **New hook**: `useGoogleOneTap` - wraps Stytch's `oauth.googleOneTap.discovery.start()` API
- **Login page**: Auto-shows One Tap on page load

## How it works

1. On login page load, the hook calls Stytch's One Tap API
2. If the user has a Google account in their browser, they see a native prompt
3. One click authenticates them and redirects to `/auth/callback`
4. If One Tap can't render (dismissed, blocked, test env), the regular login UI remains available

## Test plan

- [ ] Visit login page in Chrome with a logged-in Google account
- [ ] Verify One Tap prompt appears in top-right corner
- [ ] Click the prompt and verify successful authentication
- [ ] Dismiss the prompt and verify regular login still works
- [ ] Test in Stytch test environment (One Tap won't render - expected)