### PR TITLE
fix: resolve mypy type errors in soft delete infrastructure

### DIFF
--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -4,13 +4,10 @@ Core models - shared base classes and utilities.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Self
 
 from django.db import models
 from django.utils import timezone
-
-if TYPE_CHECKING:
-    from django.db.models import QuerySet
 
 
 class ProcessedWebhook(models.Model):
@@ -73,11 +70,11 @@ class SoftDeleteQuerySet(models.QuerySet):
         """Permanently delete records. Use for GDPR 'right to be forgotten'."""
         return super().delete()
 
-    def alive(self) -> QuerySet:
+    def alive(self) -> Self:
         """Filter to only non-deleted records."""
         return self.filter(deleted_at__isnull=True)
 
-    def dead(self) -> QuerySet:
+    def dead(self) -> Self:
         """Filter to only soft-deleted records."""
         return self.filter(deleted_at__isnull=False)
 

--- a/backend/tests/core/test_soft_delete.py
+++ b/backend/tests/core/test_soft_delete.py
@@ -22,14 +22,14 @@ class TestSoftDeleteMixin:
 
     def test_is_deleted_false_by_default(self) -> None:
         """New records should not be marked as deleted."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
 
         assert org.is_deleted is False
         assert org.deleted_at is None
 
     def test_soft_delete_sets_timestamp(self) -> None:
         """soft_delete() should set deleted_at to current time."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
 
         org.soft_delete()
 
@@ -41,7 +41,7 @@ class TestSoftDeleteMixin:
         """soft_delete() should also update the updated_at field."""
         import time
 
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
         original_updated_at = org.updated_at
         time.sleep(0.01)  # Ensure time difference
 
@@ -52,7 +52,7 @@ class TestSoftDeleteMixin:
 
     def test_soft_delete_skip_timestamp_update(self) -> None:
         """soft_delete(update_timestamp=False) should not update updated_at."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
         original_updated_at = org.updated_at
 
         org.soft_delete(update_timestamp=False)
@@ -62,7 +62,7 @@ class TestSoftDeleteMixin:
 
     def test_restore_clears_deleted_at(self) -> None:
         """restore() should clear the deleted_at timestamp."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
         org.soft_delete()
         assert org.is_deleted is True
 
@@ -76,7 +76,7 @@ class TestSoftDeleteMixin:
         """restore() should update the updated_at field."""
         import time
 
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
         org.soft_delete()
         deleted_updated_at = org.updated_at
         time.sleep(0.01)  # Ensure time difference
@@ -88,7 +88,7 @@ class TestSoftDeleteMixin:
 
     def test_hard_delete_removes_from_database(self) -> None:
         """hard_delete() should permanently remove the record."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
         org_id = org.pk
 
         org.hard_delete()
@@ -102,8 +102,8 @@ class TestSoftDeleteManager:
 
     def test_excludes_soft_deleted_records(self) -> None:
         """Default manager should not return soft-deleted records."""
-        _active_org = OrganizationFactory()
-        deleted_org = OrganizationFactory()
+        _active_org = OrganizationFactory.create()
+        deleted_org = OrganizationFactory.create()
         deleted_org.soft_delete()
 
         orgs = Organization.objects.all()
@@ -113,7 +113,7 @@ class TestSoftDeleteManager:
 
     def test_get_raises_for_deleted_record(self) -> None:
         """get() should raise DoesNotExist for soft-deleted records."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
         org_id = org.pk
         org.soft_delete()
 
@@ -122,8 +122,8 @@ class TestSoftDeleteManager:
 
     def test_filter_excludes_deleted(self) -> None:
         """filter() should exclude soft-deleted records."""
-        org1 = OrganizationFactory(name="Active Org")
-        org2 = OrganizationFactory(name="Deleted Org")
+        org1 = OrganizationFactory.create(name="Active Org")
+        org2 = OrganizationFactory.create(name="Deleted Org")
         org2.soft_delete()
 
         results = Organization.objects.filter(name__contains="Org")
@@ -137,8 +137,8 @@ class TestSoftDeleteAllManager:
 
     def test_includes_all_records(self) -> None:
         """all_objects should return both active and deleted records."""
-        active_org = OrganizationFactory()
-        deleted_org = OrganizationFactory()
+        active_org = OrganizationFactory.create()
+        deleted_org = OrganizationFactory.create()
         deleted_org.soft_delete()
 
         orgs = Organization.all_objects.all()
@@ -149,8 +149,8 @@ class TestSoftDeleteAllManager:
 
     def test_dead_returns_only_deleted(self) -> None:
         """dead() should return only soft-deleted records."""
-        _active_org = OrganizationFactory()
-        deleted_org = OrganizationFactory()
+        _active_org = OrganizationFactory.create()
+        deleted_org = OrganizationFactory.create()
         deleted_org.soft_delete()
 
         dead_orgs = Organization.all_objects.dead()
@@ -160,8 +160,8 @@ class TestSoftDeleteAllManager:
 
     def test_get_queryset_alive_method(self) -> None:
         """alive() should filter to non-deleted records."""
-        active_org = OrganizationFactory()
-        deleted_org = OrganizationFactory()
+        active_org = OrganizationFactory.create()
+        deleted_org = OrganizationFactory.create()
         deleted_org.soft_delete()
 
         alive_orgs = Organization.all_objects.get_queryset().alive()
@@ -176,9 +176,9 @@ class TestSoftDeleteQuerySet:
 
     def test_bulk_delete_soft_deletes_all(self) -> None:
         """delete() on queryset should soft delete all matching records."""
-        org1 = OrganizationFactory(name="Test Org 1")
-        org2 = OrganizationFactory(name="Test Org 2")
-        _other_org = OrganizationFactory(name="Other Org")
+        org1 = OrganizationFactory.create(name="Test Org 1")
+        org2 = OrganizationFactory.create(name="Test Org 2")
+        _other_org = OrganizationFactory.create(name="Other Org")
 
         count, details = Organization.objects.filter(name__startswith="Test").delete()
 
@@ -193,11 +193,11 @@ class TestSoftDeleteQuerySet:
 
     def test_bulk_hard_delete_removes_permanently(self) -> None:
         """hard_delete() on queryset should permanently remove records."""
-        org1 = OrganizationFactory(name="Test Org 1")
-        org2 = OrganizationFactory(name="Test Org 2")
-        _other_org = OrganizationFactory(name="Other Org")
+        org1 = OrganizationFactory.create(name="Test Org 1")
+        org2 = OrganizationFactory.create(name="Test Org 2")
+        _other_org = OrganizationFactory.create(name="Other Org")
 
-        Organization.all_objects.filter(name__startswith="Test").hard_delete()
+        Organization.all_objects.filter(name__startswith="Test").hard_delete()  # type: ignore[attr-defined]
 
         assert Organization.all_objects.count() == 1
         assert not Organization.all_objects.filter(pk=org1.pk).exists()
@@ -205,8 +205,8 @@ class TestSoftDeleteQuerySet:
 
     def test_dead_filter_on_queryset(self) -> None:
         """dead() on queryset should return deleted records."""
-        _active = OrganizationFactory()
-        deleted = OrganizationFactory()
+        _active = OrganizationFactory.create()
+        deleted = OrganizationFactory.create()
         deleted.soft_delete()
 
         dead = Organization.all_objects.get_queryset().dead()
@@ -216,8 +216,8 @@ class TestSoftDeleteQuerySet:
 
     def test_alive_filter_on_queryset(self) -> None:
         """alive() on queryset should return non-deleted records."""
-        active = OrganizationFactory()
-        deleted = OrganizationFactory()
+        active = OrganizationFactory.create()
+        deleted = OrganizationFactory.create()
         deleted.soft_delete()
 
         alive = Organization.all_objects.get_queryset().alive()
@@ -232,7 +232,7 @@ class TestMemberSoftDelete:
 
     def test_member_soft_delete(self) -> None:
         """Member model should support soft delete."""
-        member = MemberFactory()
+        member = MemberFactory.create()
 
         member.soft_delete()
 
@@ -241,7 +241,7 @@ class TestMemberSoftDelete:
 
     def test_member_restore(self) -> None:
         """Member model should support restore."""
-        member = MemberFactory()
+        member = MemberFactory.create()
         member.soft_delete()
 
         member.restore()
@@ -251,8 +251,8 @@ class TestMemberSoftDelete:
 
     def test_deleted_member_not_in_default_queryset(self) -> None:
         """Soft-deleted members should not appear in default queries."""
-        active_member = MemberFactory()
-        deleted_member = MemberFactory()
+        active_member = MemberFactory.create()
+        deleted_member = MemberFactory.create()
         deleted_member.soft_delete()
 
         members = Member.objects.all()
@@ -263,8 +263,8 @@ class TestMemberSoftDelete:
 
     def test_deleted_member_accessible_via_all_objects(self) -> None:
         """Soft-deleted members should be accessible via all_objects."""
-        _active_member = MemberFactory()
-        deleted_member = MemberFactory()
+        _active_member = MemberFactory.create()
+        deleted_member = MemberFactory.create()
         deleted_member.soft_delete()
 
         all_members = Member.all_objects.all()
@@ -274,12 +274,12 @@ class TestMemberSoftDelete:
 
     def test_unique_constraint_allows_reactivation(self) -> None:
         """Soft-deleted member should allow same user/org to create new membership."""
-        user = UserFactory()
-        org = OrganizationFactory()
-        old_member = MemberFactory(user=user, organization=org)
+        user = UserFactory.create()
+        org = OrganizationFactory.create()
+        old_member = MemberFactory.create(user=user, organization=org)
         old_member.soft_delete()
 
-        new_member = MemberFactory(user=user, organization=org)
+        new_member = MemberFactory.create(user=user, organization=org)
 
         assert new_member.pk is not None
         assert new_member.pk != old_member.pk
@@ -292,7 +292,7 @@ class TestOrganizationSoftDelete:
 
     def test_organization_soft_delete(self) -> None:
         """Organization model should support soft delete."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
 
         org.soft_delete()
 
@@ -301,7 +301,7 @@ class TestOrganizationSoftDelete:
 
     def test_organization_restore(self) -> None:
         """Organization model should support restore."""
-        org = OrganizationFactory()
+        org = OrganizationFactory.create()
         org.soft_delete()
 
         org.restore()
@@ -311,8 +311,8 @@ class TestOrganizationSoftDelete:
 
     def test_deleted_org_not_in_default_queryset(self) -> None:
         """Soft-deleted orgs should not appear in default queries."""
-        active_org = OrganizationFactory()
-        deleted_org = OrganizationFactory()
+        active_org = OrganizationFactory.create()
+        deleted_org = OrganizationFactory.create()
         deleted_org.soft_delete()
 
         orgs = Organization.objects.all()


### PR DESCRIPTION
## Summary

Fixes all 74 mypy type errors in the soft delete infrastructure.

### Changes

**`apps/core/models.py`**
- Changed `SoftDeleteQuerySet.alive()` and `dead()` return types from `QuerySet` to `Self` for proper type inference

**`tests/core/test_soft_delete.py`**
- Added `.create()` to all factory calls (`OrganizationFactory.create()`, `MemberFactory.create()`, etc.) for proper type inference with `types-factory-boy`
- Added targeted `# type: ignore[attr-defined]` for `hard_delete()` on QuerySet where mypy can't infer the custom queryset type

## Test plan
- [x] All 776 tests passing
- [x] `mypy apps/ tests/` - Success: no issues found in 150 source files
- [x] `ruff check` - All checks passed
- [x] `ruff format --check` - 190 files already formatted