### PR TITLE
refactor(infra): make construct IDs and export names configurable

### DIFF
--- a/infra/stacks/app_stack.py
+++ b/infra/stacks/app_stack.py
@@ -141,7 +141,7 @@ class AppStack(Stack):
             # Aurora Serverless v2 cluster
             self.database = rds.DatabaseCluster(
                 self,
-                "PikaiaDatabase",
+                "Database",
                 engine=rds.DatabaseClusterEngine.aurora_postgres(
                     version=rds.AuroraPostgresEngineVersion.VER_16_4,
                 ),
@@ -166,7 +166,7 @@ class AppStack(Stack):
             # This is required for Lambda functions to efficiently connect to Aurora
             self.rds_proxy = rds.DatabaseProxy(
                 self,
-                "PikaiaRdsProxy",
+                "RdsProxy",
                 proxy_target=rds.ProxyTarget.from_cluster(self.database),
                 secrets=[self.database.secret],
                 vpc=vpc,
@@ -199,19 +199,18 @@ class AppStack(Stack):
 
         self.cluster = ecs.Cluster(
             self,
-            "PikaiaCluster",
+            "Cluster",
             vpc=vpc,
             container_insights_v2=ecs.ContainerInsights.ENABLED,
         )
 
         # ECR repository for Django app - PREREQUISITE: Repository must exist
         # Using from_repository_name to handle retained repositories from previous deployments.
-        # The repository should be created via `aws ecr create-repository --repository-name pikaia-backend`
-        # or by running scripts/bootstrap-infra.sh before first deployment.
+        # The repository should be created via bootstrap-infra.sh before first deployment.
         # If the repository doesn't exist, deployment will fail with image pull errors.
         self.ecr_repository = ecr.Repository.from_repository_name(
             self,
-            "PikaiaBackendRepo",
+            "BackendRepo",
             repository_name=ecr_repository_name,
         )
 
@@ -222,7 +221,7 @@ class AppStack(Stack):
         # Task definition
         task_definition = ecs.FargateTaskDefinition(
             self,
-            "PikaiaBackendTask",
+            "BackendTask",
             cpu=512,
             memory_limit_mib=1024,
         )
@@ -471,7 +470,7 @@ class AppStack(Stack):
 
             self.fargate_service = ecs_patterns.ApplicationLoadBalancedFargateService(
                 self,
-                "PikaiaBackendService",
+                "BackendService",
                 cluster=self.cluster,
                 task_definition=task_definition,
                 desired_count=min_capacity,

--- a/infra/stacks/events_stack.py
+++ b/infra/stacks/events_stack.py
@@ -178,7 +178,7 @@ class EventsStack(Stack):
         # EventBridge bus for domain events
         self.event_bus = events.EventBus(
             self,
-            "PikaiaEventBus",
+            "EventBus",
             event_bus_name=event_bus_name,
         )
 
@@ -331,7 +331,7 @@ class EventsStack(Stack):
             "EventBusName",
             value=self.event_bus.event_bus_name,
             description="EventBridge bus name for domain events",
-            export_name="PikaiaEventBusName",
+            export_name=f"{resource_prefix.title()}EventBusName",
         )
 
         CfnOutput(
@@ -339,7 +339,7 @@ class EventsStack(Stack):
             "EventBusArn",
             value=self.event_bus.event_bus_arn,
             description="EventBridge bus ARN",
-            export_name="PikaiaEventBusArn",
+            export_name=f"{resource_prefix.title()}EventBusArn",
         )
 
         CfnOutput(
@@ -347,7 +347,7 @@ class EventsStack(Stack):
             "DLQUrl",
             value=self.dlq.queue_url,
             description="Dead Letter Queue URL for failed events",
-            export_name="PikaiaEventsDLQUrl",
+            export_name=f"{resource_prefix.title()}EventsDLQUrl",
         )
 
         CfnOutput(
@@ -355,7 +355,7 @@ class EventsStack(Stack):
             "AuditDLQUrl",
             value=self.audit_dlq.queue_url,
             description="Dead Letter Queue URL for failed audit events",
-            export_name="PikaiaAuditDLQUrl",
+            export_name=f"{resource_prefix.title()}AuditDLQUrl",
         )
 
         CfnOutput(
@@ -363,7 +363,7 @@ class EventsStack(Stack):
             "AuditLambdaArn",
             value=self.audit_lambda.function_arn,
             description="Audit consumer Lambda ARN",
-            export_name="PikaiaAuditConsumerArn",
+            export_name=f"{resource_prefix.title()}AuditConsumerArn",
         )
 
         CfnOutput(
@@ -371,5 +371,5 @@ class EventsStack(Stack):
             "PublisherLambdaArn",
             value=self.publisher_lambda.function_arn,
             description="Event publisher Lambda ARN",
-            export_name="PikaiaEventPublisherArn",
+            export_name=f"{resource_prefix.title()}EventPublisherArn",
         )

--- a/infra/stacks/media_stack.py
+++ b/infra/stacks/media_stack.py
@@ -63,6 +63,9 @@ class MediaStack(Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
+        # Resource naming from CDK context
+        resource_prefix = self.node.try_get_context("resource_prefix") or "pikaia"
+
         # S3 bucket for media files (private, accessed via CloudFront)
         self.bucket = s3.Bucket(
             self,
@@ -144,7 +147,7 @@ class MediaStack(Stack):
             self,
             "MediaDistribution",
             default_behavior=default_behavior_config,
-            comment="Pikaia Media CDN with image transformation",
+            comment=f"{resource_prefix.title()} Media CDN with image transformation",
             price_class=cloudfront.PriceClass.PRICE_CLASS_100,  # US, Canada, Europe
         )
 
@@ -154,7 +157,7 @@ class MediaStack(Stack):
             "BucketName",
             value=self.bucket.bucket_name,
             description="S3 bucket name for media storage",
-            export_name="PikaiaMediaBucketName",
+            export_name=f"{resource_prefix.title()}MediaBucketName",
         )
 
         CfnOutput(
@@ -162,7 +165,7 @@ class MediaStack(Stack):
             "DistributionDomainName",
             value=self.distribution.distribution_domain_name,
             description="CloudFront distribution domain name",
-            export_name="PikaiaMediaCdnDomain",
+            export_name=f"{resource_prefix.title()}MediaCdnDomain",
         )
 
         CfnOutput(
@@ -170,7 +173,7 @@ class MediaStack(Stack):
             "ImageTransformUrl",
             value=f"https://{self.distribution.distribution_domain_name}",
             description="Base URL for image transformation (set as IMAGE_TRANSFORM_URL)",
-            export_name="PikaiaImageTransformUrl",
+            export_name=f"{resource_prefix.title()}ImageTransformUrl",
         )
 
     def _create_origin_request_lambda(self) -> lambda_.Function:

--- a/infra/stacks/network_stack.py
+++ b/infra/stacks/network_stack.py
@@ -39,7 +39,7 @@ class NetworkStack(Stack):
         # CDK lookup caching issues in CI/CD environments
         self.vpc = ec2.Vpc(
             self,
-            "PikaiaVpc",
+            "Vpc",
             max_azs=2 if not availability_zones else None,
             availability_zones=availability_zones,
             nat_gateways=1,  # Cost optimization: single NAT for dev

--- a/infra/stacks/observability_stack.py
+++ b/infra/stacks/observability_stack.py
@@ -465,7 +465,7 @@ class ObservabilityStack(Stack):
 
         dashboard = cloudwatch.Dashboard(
             self,
-            "PikaiaDashboard",
+            "Dashboard",
             dashboard_name=dashboard_name,
         )
 
@@ -656,7 +656,7 @@ class ObservabilityStack(Stack):
             "AlarmTopicArn",
             value=self.alarm_topic.topic_arn,
             description="SNS Topic ARN for alarm notifications",
-            export_name="PikaiaAlarmTopicArn",
+            export_name=f"{resource_prefix.title()}AlarmTopicArn",
         )
 
     def _create_lambda_metrics(


### PR DESCRIPTION
## Summary

- Replace hardcoded "Pikaia" in CDK construct IDs and CloudFormation export names with configurable `resource_prefix` from CDK context
- Enables downstream forks to customize naming without code changes

## Changes

| File | Changes |
|------|---------|
| `app_stack.py` | Generic construct IDs: Database, RdsProxy, Cluster, BackendRepo, BackendTask, BackendService |
| `network_stack.py` | Generic construct ID: Vpc |
| `events_stack.py` | Generic construct ID: EventBus; configurable export names |
| `media_stack.py` | Added resource_prefix; configurable comment and export names |
| `observability_stack.py` | Generic construct ID: Dashboard; configurable AlarmTopicArn export |

## Usage

Downstream forks can now set the resource prefix via CDK context:

```bash
cdk deploy --context resource_prefix=myapp
```

This will result in CloudFormation export names like `MyappEventBusName` instead of `PikaiaEventBusName`.

## Test plan

- [ ] `cdk synth` succeeds with default prefix
- [ ] `cdk synth --context resource_prefix=custom` produces expected export names