### PR TITLE
Include exception details in _sync_subscription_quantity_safe logging

### DIFF
--- a/backend/apps/accounts/services.py
+++ b/backend/apps/accounts/services.py
@@ -432,7 +432,11 @@ def _sync_subscription_quantity_safe(organization: Organization) -> None:
 
         sync_subscription_quantity(organization)
     except Exception:
-        logger.warning("billing_subscription_quantity_sync_failed", org_id=str(organization.id))
+        logger.warning(
+            "billing_subscription_quantity_sync_failed",
+            org_id=str(organization.id),
+            exc_info=True,
+        )
 
 
 def sync_logo_to_stytch(organization: Organization) -> None:


### PR DESCRIPTION
## Summary
- Added `exc_info=True` to the `logger.warning` call in `_sync_subscription_quantity_safe` so that exception tracebacks are included in the log output when subscription quantity sync fails.

Closes #86

## Test plan
- [ ] Verify that when `sync_subscription_quantity` raises an exception, the warning log entry now includes the full traceback.