### PR TITLE
Disable cancel-in-progress on deploy workflow

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: deploy-backend
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Set `cancel-in-progress: false` in the `deploy-ecs.yml` concurrency group to prevent new pushes from cancelling in-progress deployments, which could leave the system in a partially deployed state.

Closes #47