### PR TITLE
Pin uv version in Dockerfile instead of using :latest

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast dependency installation
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.9 /uv /usr/local/bin/uv
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Replaced `ghcr.io/astral-sh/uv:latest` with `ghcr.io/astral-sh/uv:0.9` in `backend/Dockerfile` to ensure reproducible builds by pinning to a specific minor version.

Closes #69

## Test plan
- [ ] Verify Docker build completes successfully with the pinned uv version
- [ ] Confirm dependency installation works correctly inside the container