### PR TITLE
Add httpx as direct dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "structlog>=25.5",
     "uuid6>=2024.11.27",
     "whitenoise>=6.8",
+    "httpx>=0.28",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- Add `httpx>=0.28` as a direct dependency in `backend/pyproject.toml`. The codebase imports `httpx` directly but it was only available transitively through other packages, which is fragile and could break if upstream dependencies change.

Closes #85

## Test plan
- [ ] Verify `uv lock` resolves successfully with the new dependency
- [ ] Verify `uv run python -c "import httpx"` works in a fresh virtual environment
- [ ] Confirm no version conflicts with existing transitive httpx usage