### PR TITLE
Use constant-time comparison for mobile provision API key

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -9,6 +9,7 @@ Handles Stytch B2B authentication flows:
 """
 
 import contextlib
+import secrets
 
 from django.http import HttpRequest
 from ninja import Router
@@ -303,7 +304,7 @@ def provision_mobile_user_endpoint(
         logger.error("MOBILE_PROVISION_API_KEY not configured")
         raise HttpError(401, "Mobile provisioning not configured")
 
-    if not api_key or api_key != expected_key:
+    if not api_key or not secrets.compare_digest(api_key, expected_key):
         raise HttpError(401, "Invalid or missing API key")
 
     try:


### PR DESCRIPTION
## Summary
- Replace direct string comparison (`!=`) with `secrets.compare_digest()` for the mobile provision API key check in `accounts/api.py`, preventing timing attacks
- The `not api_key` guard remains as a short-circuit so `compare_digest` always receives non-empty strings

Closes #42