### PR TITLE
Fix wrong Stripe webhook URL in production deployment guide

### DIFF
--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -156,11 +156,11 @@ PikaiaApp.LoadBalancerDNS = Pikaia-XXXXX.us-east-1.elb.amazonaws.com
 2. Click **"Add endpoint"**
 3. Enter your endpoint URL:
    ```
-   https://your-domain.com/api/v1/billing/webhooks/stripe/
+   https://your-domain.com/webhooks/stripe/
    ```
    Or for testing (HTTP):
    ```
-   http://YOUR_ALB_URL/api/v1/billing/webhooks/stripe/
+   http://YOUR_ALB_URL/webhooks/stripe/
    ```
 4. Select events:
    - `checkout.session.completed`


### PR DESCRIPTION
## Summary
- Corrected the Stripe webhook endpoint URL in the production deployment guide from `/api/v1/billing/webhooks/stripe/` to `/webhooks/stripe/`, matching the actual route defined in `backend/config/urls.py`

Closes #72

## Test plan
- [ ] Verify the URLs in Step 8 of the production deployment guide now match the webhook path in `backend/config/urls.py` (`/webhooks/stripe/`)