### PR TITLE
Remove continue-on-error from mypy CI step

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -79,7 +79,6 @@ jobs:
 
       - name: Type check (mypy)
         run: uv run mypy apps/
-        continue-on-error: true  # TODO: Remove after fixing type errors
 
       - name: Run backend tests
         run: uv run pytest --tb=short


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from the mypy type check step in the backend CI workflow, so type checking failures are no longer silently ignored.

Closes #63