### PR TITLE
Add select_related('user') to webhook member lookups

### DIFF
--- a/backend/apps/accounts/webhooks.py
+++ b/backend/apps/accounts/webhooks.py
@@ -115,7 +115,7 @@ def handle_member_updated(data: dict) -> None:
         return
 
     try:
-        member = Member.objects.get(stytch_member_id=stytch_member_id)
+        member = Member.objects.select_related("user").get(stytch_member_id=stytch_member_id)
     except Member.DoesNotExist:
         logger.info("stytch_webhook_member_not_found", stytch_member_id=stytch_member_id)
         return
@@ -164,7 +164,7 @@ def handle_member_deleted(data: dict) -> None:
         return
 
     try:
-        member = Member.objects.get(stytch_member_id=member_id)
+        member = Member.objects.select_related("user").get(stytch_member_id=member_id)
     except Member.DoesNotExist:
         logger.debug("stytch_webhook_member_already_deleted", stytch_member_id=member_id)
         return


### PR DESCRIPTION
## Summary
- Added `select_related("user")` to `Member.objects.get(...)` calls in `handle_member_updated` and `handle_member_deleted` webhook handlers to avoid extra database queries when accessing `member.user`.

Closes #62

## Test plan
- [ ] Verify webhook handlers still function correctly by triggering Stytch member update and delete events
- [ ] Confirm no N+1 queries occur when `member.user.email` is accessed in `handle_member_deleted`