### PR TITLE
Fix S3 JSON file copy path in frontend deploy workflow

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -72,7 +72,7 @@ jobs:
             --cache-control "max-age=0,no-cache,no-store,must-revalidate"
 
           # Copy any JSON files (like manifest) with short cache
-          find frontend/dist -name "*.json" -exec aws s3 cp {} "s3://${FRONTEND_BUCKET}/{}" \
+          cd frontend/dist && find . -name "*.json" -exec aws s3 cp {} "s3://${FRONTEND_BUCKET}/{}" \
             --cache-control "max-age=0,no-cache" \;
 
       - name: Invalidate CloudFront cache


### PR DESCRIPTION
## Summary
- Fixed the `find -exec` command in the frontend deploy workflow that was producing incorrect S3 destination paths
- The `find frontend/dist` command expanded `{}` to full local paths (e.g., `frontend/dist/manifest.json`), causing JSON files to be uploaded to `s3://bucket/frontend/dist/manifest.json` instead of `s3://bucket/manifest.json`
- Changed to `cd frontend/dist && find .` so that `{}` expands to relative paths like `./manifest.json`

Closes #71