### PR TITLE
Add missing architecture docs to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,12 @@ Technical documentation for Pikaia.
 ### Architecture
 - [Overview](./architecture/overview.md) — System architecture and design decisions
 - [Data Models](./architecture/data-models.md) — Database schema and relationships
+- [Events](./architecture/events.md) — Event-driven architecture and EventBridge usage patterns
+- [Integrations](./architecture/integrations.md) — External webhooks, automation platforms, and third-party services
+- [Setup Script Design](./architecture/setup-script-design.md) — Minimal-conflict setup experience via `npx pikaia-setup`
+- [Shared Infrastructure](./architecture/shared-infrastructure.md) — Shared infrastructure mode for multi-project AWS deployments
+- [Sync Engine](./architecture/sync.md) — Offline-first sync engine for mobile and desktop applications
+- [Sync Engine - iOS Client](./architecture/sync-client-ios.md) — iOS Swift implementation of the sync engine
 
 ### Features
 - [Authentication](./features/authentication.md) — Stytch B2B auth flow


### PR DESCRIPTION
## Summary
- Added 6 missing architecture doc links to `docs/README.md`: Events, Integrations, Setup Script Design, Shared Infrastructure, Sync Engine, and Sync Engine - iOS Client
- All 6 documents already existed in `docs/architecture/` but were not referenced from the docs index page

Closes #82

## Test plan
- [ ] Verify all 6 new links in `docs/README.md` resolve to valid files
- [ ] Confirm no existing links were modified or removed