### PR TITLE
Add ECR lifecycle policy to expire old images

### DIFF
--- a/scripts/bootstrap-infra.sh
+++ b/scripts/bootstrap-infra.sh
@@ -64,6 +64,29 @@ else
     echo_info "ECR repository created successfully"
 fi
 
+# Apply lifecycle policy to expire untagged images after 30 days
+echo_info "Applying ECR lifecycle policy to: $ECR_REPO_NAME"
+aws ecr put-lifecycle-policy \
+    --repository-name "$ECR_REPO_NAME" \
+    --lifecycle-policy-text '{
+        "rules": [
+            {
+                "rulePriority": 1,
+                "description": "Expire untagged images after 30 days",
+                "selection": {
+                    "tagStatus": "untagged",
+                    "countType": "sinceImagePushed",
+                    "countUnit": "days",
+                    "countNumber": 30
+                },
+                "action": {
+                    "type": "expire"
+                }
+            }
+        ]
+    }' > /dev/null
+echo_info "ECR lifecycle policy applied successfully"
+
 # =============================================================================
 # Secrets Manager Secret (placeholder - real values via bootstrap-secrets.sh)
 # =============================================================================


### PR DESCRIPTION
## Summary
- Adds an ECR lifecycle policy to the bootstrap infrastructure script that automatically expires untagged images after 30 days
- The policy is applied idempotently on every run, ensuring both new and existing repositories get the lifecycle rule
- Prevents accumulation of old untagged images in the ECR repository

Closes #70