### PR TITLE
Extract UserInfo.from_model() classmethod to reduce duplication

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -411,13 +411,7 @@ def get_current_user(request: AuthenticatedHttpRequest) -> MeResponse:
     user, member, org = get_auth_context(request)
 
     return MeResponse(
-        user=UserInfo(
-            id=user.id,
-            email=user.email,
-            name=user.name,
-            avatar_url=user.avatar_url,
-            phone_number=user.phone_number,
-        ),
+        user=UserInfo.from_model(user),
         member=MemberInfo(
             id=member.id,
             stytch_member_id=member.stytch_member_id,
@@ -484,13 +478,7 @@ def update_profile(request: AuthenticatedHttpRequest, payload: UpdateProfileRequ
         organization_id=str(org.id),
     )
 
-    return UserInfo(
-        id=user.id,
-        email=user.email,
-        name=user.name,
-        avatar_url=user.avatar_url,
-        phone_number=user.phone_number,
-    )
+    return UserInfo.from_model(user)
 
 
 # --- Phone Verification ---
@@ -599,13 +587,7 @@ def verify_phone_otp(request: AuthenticatedHttpRequest, payload: VerifyPhoneOtpR
             organization_id=str(org.id),
         )
 
-        return UserInfo(
-            id=user.id,
-            email=user.email,
-            name=user.name,
-            avatar_url=user.avatar_url,
-            phone_number=user.phone_number,
-        )
+        return UserInfo.from_model(user)
 
     except StytchError as e:
         error_msg = e.details.error_message or "Verification failed"

--- a/backend/apps/accounts/schemas.py
+++ b/backend/apps/accounts/schemas.py
@@ -2,9 +2,15 @@
 Auth API schemas - Pydantic models for request/response.
 """
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
+
+if TYPE_CHECKING:
+    from apps.accounts.models import User
 
 # Stytch slug requirements: 2-128 chars, lowercase alphanumeric + ._~-
 _SLUG_ALLOWED_CHARS = re.compile(r"[^a-z0-9._~-]+")
@@ -263,6 +269,17 @@ class UserInfo(BaseModel):
     name: str = Field(..., description="User's display name")
     avatar_url: str = Field("", description="URL to user's avatar image")
     phone_number: str = Field("", description="Phone number in E.164 format")
+
+    @classmethod
+    def from_model(cls, user: User) -> UserInfo:
+        """Create UserInfo from a User model instance."""
+        return cls(
+            id=user.id,
+            email=user.email,
+            name=user.name,
+            avatar_url=user.avatar_url,
+            phone_number=user.phone_number,
+        )
 
 
 class MeResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Added a `from_model(cls, user)` classmethod to `UserInfo` in `schemas.py` that constructs a `UserInfo` instance from a `User` model
- Replaced 3 identical manual `UserInfo(...)` constructions in `api.py` (`get_current_user`, `update_profile`, `verify_phone_otp`) with `UserInfo.from_model(user)`
- Used `TYPE_CHECKING` guard for the `User` model import to avoid circular imports at runtime

Closes #75

## Test plan
- [x] All 891 existing backend tests pass with no changes needed