### PR TITLE
Fix health check path inconsistency between Dockerfile and ECS

### DIFF
--- a/infra/stacks/app_stack.py
+++ b/infra/stacks/app_stack.py
@@ -352,7 +352,7 @@ class AppStack(Stack):
                 ),
             },
             health_check=ecs.HealthCheck(
-                command=["CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1"],
+                command=["CMD-SHELL", "curl -f http://localhost:8000/api/v1/health || exit 1"],
                 interval=Duration.seconds(30),
                 timeout=Duration.seconds(5),
                 retries=3,


### PR DESCRIPTION
## Summary
- Aligned the ECS container health check path from `/health/` to `/api/v1/health` to match the Dockerfile and ALB target group health checks, which all point to the Django Ninja health endpoint defined at `api/v1/health`.

## Test plan
- [ ] Verify ECS container health checks pass after deployment
- [ ] Confirm ALB target group health checks continue to work
- [ ] Validate Dockerfile HEALTHCHECK still works in local Docker builds

Closes #50