### PR TITLE
Add webhook secrets to ECS config and production startup validation

### DIFF
--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -55,6 +55,8 @@ _REQUIRED_SECRETS = {
     "STYTCH_SECRET": settings.STYTCH_SECRET,
     "STRIPE_SECRET_KEY": settings.STRIPE_SECRET_KEY,
     "STRIPE_PRICE_ID": settings.STRIPE_PRICE_ID,
+    "STRIPE_WEBHOOK_SECRET": settings.STRIPE_WEBHOOK_SECRET,
+    "STYTCH_WEBHOOK_SECRET": settings.STYTCH_WEBHOOK_SECRET,
 }
 
 # Secrets that have obviously insecure defaults

--- a/infra/stacks/app_stack.py
+++ b/infra/stacks/app_stack.py
@@ -296,6 +296,10 @@ class AppStack(Stack):
                     self.app_secrets,
                     field="STYTCH_SECRET",
                 ),
+                "STYTCH_WEBHOOK_SECRET": ecs.Secret.from_secrets_manager(
+                    self.app_secrets,
+                    field="STYTCH_WEBHOOK_SECRET",
+                ),
                 "STRIPE_SECRET_KEY": ecs.Secret.from_secrets_manager(
                     self.app_secrets,
                     field="STRIPE_SECRET_KEY",

--- a/scripts/bootstrap-secrets.sh
+++ b/scripts/bootstrap-secrets.sh
@@ -64,6 +64,7 @@ REQUIRED_VARS=(
     "STRIPE_SECRET_KEY"
     "STRIPE_PRICE_ID"
     "STRIPE_WEBHOOK_SECRET"
+    "STYTCH_WEBHOOK_SECRET"
     "RESEND_API_KEY"
 )
 
@@ -116,6 +117,7 @@ SECRET_JSON=$(jq -n \
     --arg stripe_key "$STRIPE_SECRET_KEY" \
     --arg stripe_price "$STRIPE_PRICE_ID" \
     --arg stripe_webhook "$STRIPE_WEBHOOK_SECRET" \
+    --arg stytch_webhook "$STYTCH_WEBHOOK_SECRET" \
     --arg resend_key "$RESEND_API_KEY" \
     --arg trusted_profile "${STYTCH_TRUSTED_AUTH_PROFILE_ID:-}" \
     --arg trusted_audience "${STYTCH_TRUSTED_AUTH_AUDIENCE:-stytch}" \
@@ -133,6 +135,7 @@ SECRET_JSON=$(jq -n \
         STRIPE_SECRET_KEY: $stripe_key,
         STRIPE_PRICE_ID: $stripe_price,
         STRIPE_WEBHOOK_SECRET: $stripe_webhook,
+        STYTCH_WEBHOOK_SECRET: $stytch_webhook,
         RESEND_API_KEY: $resend_key,
         STYTCH_TRUSTED_AUTH_PROFILE_ID: $trusted_profile,
         STYTCH_TRUSTED_AUTH_AUDIENCE: $trusted_audience,


### PR DESCRIPTION
## Summary
- Add `STYTCH_WEBHOOK_SECRET` to ECS container secrets in `app_stack.py` so it is injected as an environment variable at runtime
- Add `STYTCH_WEBHOOK_SECRET` to `bootstrap-secrets.sh` required vars, jq arguments, and JSON template so it is persisted to AWS Secrets Manager during setup
- Add both `STYTCH_WEBHOOK_SECRET` and `STRIPE_WEBHOOK_SECRET` to `_REQUIRED_SECRETS` in `production.py` so the application fails fast at startup if either is missing

## Test plan
- [ ] Verify `cdk synth` still produces valid CloudFormation with the new secret mapping
- [ ] Verify `bootstrap-secrets.sh` fails if `STYTCH_WEBHOOK_SECRET` is missing from `.env.production`
- [ ] Verify production settings validation rejects startup when `STRIPE_WEBHOOK_SECRET` or `STYTCH_WEBHOOK_SECRET` is empty

Closes #43