### PR TITLE
Pass secrets via stdin instead of CLI arguments in bootstrap script

### DIFF
--- a/scripts/bootstrap-secrets.sh
+++ b/scripts/bootstrap-secrets.sh
@@ -149,7 +149,7 @@ SECRET_JSON=$(jq -n \
 # Update secrets
 echo_info "Updating secret: $SECRET_NAME"
 
-VERSION_ID=$(echo "$SECRET_JSON" | aws secretsmanager put-secret-value \
+VERSION_ID=$(printf '%s' "$SECRET_JSON" | aws secretsmanager put-secret-value \
     --secret-id "$SECRET_NAME" \
     --secret-string file:///dev/stdin \
     --query 'VersionId' \


### PR DESCRIPTION
## Summary
- Pipe secret JSON via stdin to `aws secretsmanager put-secret-value` using `file:///dev/stdin` instead of passing it as a `--secret-string` CLI argument, which was visible in process listings (`ps aux`).

Closes #51

## Test plan
- [ ] Run `bootstrap-secrets.sh` against a test AWS environment and verify the secret is written correctly
- [ ] Confirm the secret value no longer appears in `ps aux` output during execution