### PR TITLE
Centralize passkey query keys in queryKeys factory

### DIFF
--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -37,4 +37,8 @@ export const queryKeys = {
     all: ['devices'] as const,
     list: () => [...queryKeys.devices.all, 'list'] as const,
   },
+  passkeys: {
+    all: ['passkeys'] as const,
+    list: () => [...queryKeys.passkeys.all, 'list'] as const,
+  },
 } as const

--- a/frontend/src/features/auth/hooks/use-passkey-auth.ts
+++ b/frontend/src/features/auth/hooks/use-passkey-auth.ts
@@ -7,6 +7,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
+import { queryKeys } from '@/api/query-keys'
 import { useApi } from '@/api/use-api'
 
 // --- API Types ---
@@ -317,7 +318,7 @@ export function useRegisterPasskey() {
     },
     onSuccess: () => {
       // Invalidate passkey list to show the new passkey
-      void queryClient.invalidateQueries({ queryKey: ['passkeys'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.passkeys.all })
     },
   })
 }
@@ -373,7 +374,7 @@ export function usePasskeys() {
   const { api } = useApi()
 
   return useQuery({
-    queryKey: ['passkeys'],
+    queryKey: queryKeys.passkeys.list(),
     queryFn: () => api.get<PasskeyListResponse>('/auth/passkeys'),
     staleTime: 30000, // 30 seconds
   })
@@ -391,7 +392,7 @@ export function useDeletePasskey() {
       return api.delete(`/auth/passkeys/${String(passkeyId)}`)
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['passkeys'] })
+      void queryClient.invalidateQueries({ queryKey: queryKeys.passkeys.all })
     },
   })
 }


### PR DESCRIPTION
## Summary
- Added a `passkeys` entry (with `all` and `list` keys) to the centralized `queryKeys` factory in `query-keys.ts`
- Replaced all hardcoded `['passkeys']` query keys in `use-passkey-auth.ts` with references to `queryKeys.passkeys`
- Aligned passkey queries with the existing pattern used by auth, organization, members, billing, webhooks, and devices

Closes #67

## Test plan
- [ ] Verify passkey list loads correctly on the settings/security page
- [ ] Register a new passkey and confirm the list refreshes automatically
- [ ] Delete a passkey and confirm the list refreshes automatically
- [ ] Confirm no TypeScript compilation errors