### PR TITLE
Fix stale references and 'Future' labels in architecture docs

### DIFF
--- a/docs/architecture/events.md
+++ b/docs/architecture/events.md
@@ -109,6 +109,7 @@ The following events are currently integrated into the codebase:
 | Event Type | Aggregate | Trigger Location |
 |------------|-----------|------------------|
 | `organization.created` | Organization | `accounts/api.py` - create_organization |
+| `organization.deleted` | Organization | `accounts/webhooks.py` - handle_organization_deleted |
 | `member.invited` | Member | `accounts/api.py` - invite_member_endpoint |
 | `member.joined` | Member | `accounts/api.py` - exchange_session |
 | `member.removed` | Member | `accounts/api.py` + `accounts/webhooks.py` |
@@ -208,21 +209,7 @@ def handle_time_entry_created(event: dict):
 
 ### Documentation
 
-Event schemas are documented in `/docs/events/` with one file per event type:
-
-```
-docs/events/
-├── time_entry.created.md
-├── time_entry.submitted.md
-├── user.phone_number_changed.md
-└── ...
-```
-
-Each file contains:
-- Overview and purpose
-- Schema versions with field tables
-- Breaking changes log
-- Example payloads
+> **Planned:** Per-event schema documentation will be added in `/docs/events/` with one file per event type (e.g., `time_entry.created.md`). Each file will contain overview, schema versions, breaking changes log, and example payloads.
 
 ---
 
@@ -656,14 +643,14 @@ pipe = pipes.CfnPipe(
 
 ### In-Repo JSON Schemas
 
-Store schemas in `/schemas/events/` and validate on publish:
-
-```
-schemas/events/
-├── time_entry.created.v1.json
-├── time_entry.approved.v1.json
-└── public.time_entry.created.v1.json
-```
+> **Planned:** JSON schemas will be stored in `/schemas/events/` and validated on publish. Example structure:
+>
+> ```
+> schemas/events/
+> ├── time_entry.created.v1.json
+> ├── time_entry.approved.v1.json
+> └── public.time_entry.created.v1.json
+> ```
 
 ### Example Schema
 
@@ -723,16 +710,15 @@ def publish_event(event: dict):
 
 ### Enforcing Additive Changes
 
-CI check to prevent breaking schema changes:
-
-```bash
-# .github/workflows/schema-check.yml
-- name: Check schema compatibility
-  run: |
-    python scripts/check_schema_compatibility.py \
-      --old origin/main:schemas/events/ \
-      --new schemas/events/
-```
+> **Planned:** A CI check will be added to prevent breaking schema changes. Example workflow (`.github/workflows/schema-check.yml`):
+>
+> ```bash
+> - name: Check schema compatibility
+>   run: |
+>     python scripts/check_schema_compatibility.py \
+>       --old origin/main:schemas/events/ \
+>       --new schemas/events/
+> ```
 
 ---
 

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -404,17 +404,22 @@ def stripe_webhook(request):
     return HttpResponse(status=200)
 ```
 
-### Stytch Webhooks (Future)
+### Stytch Webhooks
 
-For real-time auth events:
+Implemented in `apps/accounts/webhooks.py` for real-time auth event synchronization.
+Stytch uses Svix for webhook delivery; signatures are verified via the `svix` Python SDK.
 
-```python
-@router.post("/webhooks/stytch")
-def stytch_webhook(request):
-    # Verify signature using Stytch SDK
-    # Handle: member.created, member.deleted, organization.updated
-    ...
-```
+**Handled events:**
+
+| Event | Action |
+|-------|--------|
+| `*.member.create` | Create member in local DB if missing (reconciliation) |
+| `*.member.update` | Sync role changes and status updates |
+| `*.member.delete` | Soft delete local member |
+| `*.organization.update` | Sync name, slug, and logo changes |
+| `*.organization.delete` | Soft delete organization and all its members |
+
+**Endpoint:** `POST /webhooks/stytch/` (configured in `config/urls.py`)
 
 ### Inbound Webhook Best Practices
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -75,7 +75,9 @@ flowchart TD
     I --> J
 ```
 
-**Public Paths:** `/api/v1/auth/magic-link/*`, `/api/v1/health`, `/admin/*`, `/webhooks/stripe/`, `/webhooks/stytch/`
+**Public Paths (middleware-defined):** `/api/v1/health`, `/api/v1/auth/magic-link/send`, `/api/v1/auth/magic-link/authenticate`, `/api/v1/auth/discovery/create-org`, `/api/v1/auth/discovery/exchange`, `/api/v1/auth/mobile/provision`, `/admin/`
+
+> **Note:** Webhook endpoints (`/webhooks/stripe/`, `/webhooks/stytch/`) and passkey authentication endpoints (`/auth/passkeys/authenticate/*`) are served outside the auth middleware scope and handle their own verification.
 
 ## Role-Based Access
 
@@ -105,15 +107,17 @@ Stytch webhooks provide real-time synchronization when changes occur outside aut
 
 | Event | Action |
 |-------|--------|
+| `*.member.create` | Create member in local DB if missing (reconciliation) |
 | `*.member.update` | Sync role changes, status updates |
 | `*.member.delete` | Soft delete local member |
 | `*.organization.update` | Sync name, slug, logo changes |
+| `*.organization.delete` | Soft delete organization and all its members |
 
 ### Setup
 
 1. Configure webhook endpoint in Stytch Dashboard: `https://yourapp.com/webhooks/stytch/`
 2. Copy the signing secret to `STYTCH_WEBHOOK_SECRET` environment variable
-3. Enable events: `member.update`, `member.delete`, `organization.update`
+3. Enable events: `member.create`, `member.update`, `member.delete`, `organization.update`, `organization.delete`
 
 > **Note:** Webhooks use Svix for delivery with automatic retries and signature verification.
 

--- a/docs/operations/webhooks.md
+++ b/docs/operations/webhooks.md
@@ -28,12 +28,12 @@ Organizations can configure webhook endpoints to receive HTTP POST requests when
    - API: CRUD for endpoints, delivery logs, test sends
    - Event catalog: Single source of truth for available events
 
-2. **EventBridge Consumer Lambda** (`infra/functions/webhook-dispatcher/`)
+2. **EventBridge Consumer Lambda** (Planned: `infra/functions/webhook-dispatcher/`)
    - Triggered by EventBridge rules for webhook-eligible events
    - Looks up subscribed endpoints per organization
    - Dispatches HTTP requests with signatures
 
-3. **CDK Infrastructure** (`infra/stacks/webhooks_stack.py`)
+3. **CDK Infrastructure** (Planned: `infra/stacks/webhooks_stack.py`)
    - Lambda function with DLQ
    - EventBridge rules
    - CloudWatch alarms


### PR DESCRIPTION
## Summary

- **integrations.md**: Updated Stytch Webhooks section from "(Future)" stub to reflect the fully implemented handlers (`member.create`, `member.update`, `member.delete`, `organization.update`, `organization.delete`) with accurate details about Svix signature verification
- **authentication.md**: Corrected public paths to match the actual `PUBLIC_PATHS` set in `StytchAuthMiddleware`, added note about webhook/passkey endpoints being outside middleware scope, and added missing `member.create` and `organization.delete` webhook events
- **events.md**: Added missing `organization.deleted` event to implemented events list; marked non-existent `docs/events/`, `schemas/events/`, and `.github/workflows/schema-check.yml` references as "Planned"
- **webhooks.md**: Marked non-existent `infra/functions/webhook-dispatcher/` and `infra/stacks/webhooks_stack.py` references as "Planned"

Closes #83

## Test plan

- [ ] Verify all four modified docs render correctly in GitHub markdown preview
- [ ] Confirm no broken internal links were introduced
- [ ] Cross-reference public paths with `backend/apps/core/middleware.py` `PUBLIC_PATHS`
- [ ] Cross-reference webhook events with `backend/apps/accounts/webhooks.py` handlers