### PR TITLE
Add update_fields to .save() calls across backend

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -787,6 +787,15 @@ def update_billing(
     org.billing_name = payload.billing_name
     org.vat_id = payload.vat_id
 
+    update_fields = [
+        "use_billing_email",
+        "billing_name",
+        "vat_id",
+        "updated_at",
+    ]
+    if payload.billing_email is not None:
+        update_fields.append("billing_email")
+
     if payload.address:
         org.billing_address_line1 = payload.address.line1
         org.billing_address_line2 = payload.address.line2
@@ -794,8 +803,18 @@ def update_billing(
         org.billing_state = payload.address.state
         org.billing_postal_code = payload.address.postal_code
         org.billing_country = payload.address.country
+        update_fields.extend(
+            [
+                "billing_address_line1",
+                "billing_address_line2",
+                "billing_city",
+                "billing_state",
+                "billing_postal_code",
+                "billing_country",
+            ]
+        )
 
-    org.save()
+    org.save(update_fields=update_fields)
 
     # Sync billing info to Stripe
     if org.stripe_customer_id:

--- a/backend/apps/accounts/webhooks.py
+++ b/backend/apps/accounts/webhooks.py
@@ -129,7 +129,7 @@ def handle_member_updated(data: dict) -> None:
             break
 
     # Update member fields
-    updated = False
+    update_fields: list[str] = []
     if member.role != new_role:
         logger.info(
             "stytch_webhook_member_role_updated",
@@ -138,17 +138,18 @@ def handle_member_updated(data: dict) -> None:
             new_role=new_role,
         )
         member.role = new_role
-        updated = True
+        update_fields.append("role")
 
     # Check for status changes (deactivated via SCIM, etc.)
     status = member_data.get("status")
     if status == "deleted" and member.deleted_at is None:
         logger.info("stytch_webhook_member_deleted", stytch_member_id=stytch_member_id)
         member.deleted_at = datetime.now(UTC)
-        updated = True
+        update_fields.append("deleted_at")
 
-    if updated:
-        member.save()
+    if update_fields:
+        update_fields.append("updated_at")
+        member.save(update_fields=update_fields)
 
 
 def handle_member_deleted(data: dict) -> None:
@@ -206,7 +207,7 @@ def handle_organization_updated(data: dict) -> None:
         return
 
     # Update fields that may have changed
-    updated = False
+    update_fields: list[str] = []
 
     new_name = org_data.get("organization_name")
     if new_name and org.name != new_name:
@@ -217,7 +218,7 @@ def handle_organization_updated(data: dict) -> None:
             new_name=new_name,
         )
         org.name = new_name
-        updated = True
+        update_fields.append("name")
 
     new_slug = org_data.get("organization_slug")
     if new_slug and org.slug != new_slug:
@@ -228,16 +229,17 @@ def handle_organization_updated(data: dict) -> None:
             new_slug=new_slug,
         )
         org.slug = new_slug
-        updated = True
+        update_fields.append("slug")
 
     # Sync logo if changed
     new_logo = org_data.get("organization_logo_url", "")
     if org.logo_url != new_logo:
         org.logo_url = new_logo
-        updated = True
+        update_fields.append("logo_url")
 
-    if updated:
-        org.save()
+    if update_fields:
+        update_fields.append("updated_at")
+        org.save(update_fields=update_fields)
 
 
 def handle_organization_deleted(data: dict) -> None:

--- a/backend/apps/billing/services.py
+++ b/backend/apps/billing/services.py
@@ -449,7 +449,16 @@ def handle_subscription_updated(stripe_subscription: dict) -> None:
     subscription.current_period_start = period_start
     subscription.current_period_end = period_end
     subscription.cancel_at_period_end = stripe_subscription.get("cancel_at_period_end", False)
-    subscription.save()
+    subscription.save(
+        update_fields=[
+            "status",
+            "quantity",
+            "current_period_start",
+            "current_period_end",
+            "cancel_at_period_end",
+            "updated_at",
+        ]
+    )
 
     # Emit subscription.updated event if there are meaningful changes
     if old_status != subscription.status or old_quantity != subscription.quantity:


### PR DESCRIPTION
## Summary
- Add `update_fields` to four `.save()` calls that were triggering full-row UPDATEs
- `accounts/webhooks.py`: member save after role/deleted_at update now uses dynamic `update_fields` list
- `accounts/webhooks.py`: organization save after name/slug/logo_url update now uses dynamic `update_fields` list
- `accounts/api.py`: organization billing save now specifies all modified billing fields
- `billing/services.py`: subscription save after Stripe webhook update now specifies all five updated fields
- All lists include `updated_at` to ensure the `auto_now` timestamp is written

Closes #58

## Test plan
- [ ] Verify member role update via Stytch webhook only writes `role` and `updated_at`
- [ ] Verify member soft-delete via Stytch webhook only writes `deleted_at` and `updated_at`
- [ ] Verify organization update via Stytch webhook only writes changed fields and `updated_at`
- [ ] Verify billing update endpoint only writes billing fields and `updated_at`
- [ ] Verify subscription update from Stripe webhook only writes subscription fields and `updated_at`
- [ ] Run existing test suite to confirm no regressions