### PR TITLE
Fix blob URL memory leak in getDirectoryAvatar

### DIFF
--- a/frontend/src/hooks/use-blob-urls.ts
+++ b/frontend/src/hooks/use-blob-urls.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Manages a keyed record of blob URLs with automatic cleanup.
+ *
+ * Revokes all blob URLs when the component unmounts to prevent memory leaks
+ * from `URL.createObjectURL()`.
+ */
+export function useBlobUrls() {
+  const [urls, setUrls] = useState<Record<string, string>>({})
+  const urlsRef = useRef<Record<string, string>>({})
+
+  // Keep ref in sync with state so cleanup always has latest values
+  useEffect(() => {
+    urlsRef.current = urls
+  }, [urls])
+
+  const addUrl = useCallback((key: string, blobUrl: string) => {
+    setUrls((prev) => {
+      // Revoke old URL for this key if it exists and differs
+      if (prev[key] && prev[key] !== blobUrl) {
+        URL.revokeObjectURL(prev[key])
+      }
+      return { ...prev, [key]: blobUrl }
+    })
+  }, [])
+
+  const clearAll = useCallback(() => {
+    setUrls((prev) => {
+      for (const blobUrl of Object.values(prev)) {
+        URL.revokeObjectURL(blobUrl)
+      }
+      return {}
+    })
+  }, [])
+
+  const hasUrl = useCallback((key: string) => Boolean(urlsRef.current[key]), [])
+
+  const getUrl = useCallback((key: string) => urlsRef.current[key] as string | undefined, [])
+
+  // Revoke all blob URLs on unmount
+  useEffect(() => {
+    return () => {
+      for (const blobUrl of Object.values(urlsRef.current)) {
+        URL.revokeObjectURL(blobUrl)
+      }
+    }
+  }, [])
+
+  return { urls, addUrl, clearAll, hasUrl, getUrl }
+}


### PR DESCRIPTION
## Summary
- Created a reusable `useBlobUrls` hook that manages the lifecycle of blob URLs created via `URL.createObjectURL()`, automatically revoking them on unmount and when replaced
- Updated `EmailAutocomplete` to use `useBlobUrls` instead of raw `useState` for avatar URL storage, preventing memory leaks from unrevoked blob URLs

## Test plan
- [ ] Verify autocomplete suggestions still display user avatars correctly
- [ ] Confirm blob URLs are revoked when the component unmounts (inspect via DevTools Memory tab)
- [ ] Confirm no regressions in the invite member flow with directory search

Closes #61