### PR TITLE
Extract duplicated billing email resolution and Stripe period parsing

### DIFF
--- a/backend/apps/accounts/webhooks.py
+++ b/backend/apps/accounts/webhooks.py
@@ -15,7 +15,11 @@ from django.views.decorators.http import require_POST
 from svix.webhooks import Webhook, WebhookVerificationError
 
 from apps.accounts.models import Member
-from apps.accounts.services import get_or_create_member_from_stytch, get_or_create_user_from_stytch
+from apps.accounts.services import (
+    _parse_stytch_role,
+    get_or_create_member_from_stytch,
+    get_or_create_user_from_stytch,
+)
 from apps.core.logging import get_logger
 from apps.core.webhooks import mark_webhook_processed
 from apps.events.services import publish_event
@@ -63,12 +67,7 @@ def handle_member_created(data: dict) -> None:
         return
 
     # Determine role from Stytch RBAC
-    roles = member_data.get("roles", [])
-    role = "member"
-    for r in roles:
-        if isinstance(r, dict) and r.get("role_id") == "stytch_admin":
-            role = "admin"
-            break
+    role = _parse_stytch_role(member_data.get("roles", []))
 
     # Get or create user and member
     logger.info(
@@ -121,12 +120,7 @@ def handle_member_updated(data: dict) -> None:
         return
 
     # Update role from Stytch RBAC
-    roles = member_data.get("roles", [])
-    new_role = "member"  # Default
-    for role in roles:
-        if role.get("role_id") == "stytch_admin":
-            new_role = "admin"
-            break
+    new_role = _parse_stytch_role(member_data.get("roles", []))
 
     # Update member fields
     updated = False


### PR DESCRIPTION
## Summary
- Extract `_resolve_billing_email(org)` helper in `billing/services.py` to deduplicate billing email resolution logic used in `get_or_create_stripe_customer` and `sync_billing_to_stripe`
- Extract `_parse_stripe_period(stripe_subscription)` helper in `billing/services.py` to deduplicate Stripe period date parsing used in `handle_subscription_created` and `handle_subscription_updated`
- Extract `_parse_stytch_role(roles)` helper in `accounts/services.py` to deduplicate Stytch RBAC role parsing used across `accounts/services.py` and `accounts/webhooks.py` (3 call sites)

Closes #57

## Test plan
- [x] All 891 existing backend tests pass
- [x] Pre-commit hooks (ruff, ruff-format, mypy, conventional commit) all pass
- [x] Behavior is preserved: no new logic introduced, only extraction of existing duplicated code into reusable helpers