### PR TITLE
Add CloudWatch alarms for SQS dead letter queues

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -102,8 +102,7 @@ require_https = app.node.try_get_context("require_https") or False
 # Validate CORS configuration for production
 if require_https and cors_origins == ["*"]:
     raise ValueError(
-        "app_domain must be set when require_https=true. "
-        "Pass --context app_domain=app.example.com"
+        "app_domain must be set when require_https=true. Pass --context app_domain=app.example.com"
     )
 
 media = MediaStack(
@@ -241,6 +240,8 @@ observability = ObservabilityStack(
     event_bus=events_stack.event_bus,
     publisher_lambda=events_stack.publisher_lambda,
     audit_lambda=events_stack.audit_lambda,
+    publisher_dlq=events_stack.dlq,
+    audit_dlq=events_stack.audit_dlq,
     alarm_email=alarm_email,
     env=env,
 )


### PR DESCRIPTION
## Summary
- Add CloudWatch alarms for `ApproximateNumberOfMessagesVisible > 0` on both the event publisher DLQ and audit consumer DLQ
- Connect alarms to the existing SNS alarm topic so failed messages trigger notifications
- Include DLQ alarms in the dashboard alarm status widget for visibility

Closes #49

## Test plan
- [ ] Run `cdk synth --all` to verify the template generates without errors
- [ ] Verify the two new alarms (`PublisherDlqAlarm`, `AuditDlqAlarm`) appear in the synthesized CloudFormation template
- [ ] Confirm alarms reference the correct SQS queues and SNS topic
- [ ] Confirm the `AlarmStatusWidget` includes the new DLQ alarms