### PR TITLE
Add route-level authorization guards for admin pages

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,4 +1,4 @@
-import { useStytchMemberSession } from '@stytch/react/b2b'
+import { useStytchMember, useStytchMemberSession } from '@stytch/react/b2b'
 import { useEffect, useState } from 'react'
 import {
   type ActionFunction,
@@ -13,6 +13,7 @@ import {
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { SettingsSkeleton } from '@/components/ui/skeleton'
 import AppLayout from '@/layouts/app-layout'
+import { STYTCH_ROLES } from '@/lib/constants'
 
 // ============ Types ============
 
@@ -113,6 +114,18 @@ function ProtectedRoute({ children }: { children?: React.ReactNode }) {
   return <>{children ?? <Outlet />}</>
 }
 
+function AdminRoute({ children }: { children?: React.ReactNode }) {
+  const { member } = useStytchMember()
+  const roles = member?.roles || []
+  const isAdmin = roles.some((r: { role_id?: string }) => r.role_id === STYTCH_ROLES.ADMIN)
+
+  if (!isAdmin) {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  return <>{children ?? <Outlet />}</>
+}
+
 // ============ Routes Config ============
 
 const routes: AppRouteConfig[] = [
@@ -137,26 +150,31 @@ const routes: AppRouteConfig[] = [
         path: '/settings/organization',
         lazy: () => import('@/pages/settings/organization-settings'),
         fallback: SettingsFallback,
+        guards: [AdminRoute],
       },
       {
         path: '/settings/members',
         lazy: () => import('@/pages/settings/members-settings'),
         fallback: SettingsFallback,
+        guards: [AdminRoute],
       },
       {
         path: '/settings/billing',
         lazy: () => import('@/pages/settings/billing-settings'),
         fallback: SettingsFallback,
+        guards: [AdminRoute],
       },
       {
         path: '/settings/security',
         lazy: () => import('@/pages/settings/security-settings'),
         fallback: SettingsFallback,
+        guards: [AdminRoute],
       },
       {
         path: '/settings/integrations',
         lazy: () => import('@/pages/settings/integrations-settings'),
         fallback: SettingsFallback,
+        guards: [AdminRoute],
       },
       { path: '*', lazy: () => import('@/pages/not-found') },
     ],


### PR DESCRIPTION
## Summary
- Add `AdminRoute` guard component that checks for the `stytch_admin` role and redirects non-admin users to `/dashboard`
- Apply the `AdminRoute` guard to all admin-only settings routes: organization, members, billing, security, and integrations
- Leverages the existing composable guards system in `router.tsx` — the `AdminRoute` guard is applied on leaf routes alongside the parent `ProtectedRoute` guard

## Test plan
- [ ] Log in as a non-admin user and navigate directly to `/settings/organization` — verify redirect to `/dashboard`
- [ ] Repeat for `/settings/members`, `/settings/billing`, `/settings/security`, `/settings/integrations`
- [ ] Log in as an admin user and verify all admin settings pages are accessible
- [ ] Verify `/settings/profile` remains accessible to all authenticated users
- [ ] Verify the sidebar still correctly hides admin nav items for non-admin users

Closes #44