### PR TITLE
Hash OTP codes before database storage

### DIFF
--- a/backend/apps/sms/admin.py
+++ b/backend/apps/sms/admin.py
@@ -23,7 +23,7 @@ class OTPVerificationAdmin(admin.ModelAdmin):
     list_filter = ["purpose", "is_verified", "created_at"]
     search_fields = ["phone_number", "user__email"]
     readonly_fields = [
-        "code",
+        "code_hash",
         "created_at",
         "verified_at",
         "aws_message_id",

--- a/backend/apps/sms/migrations/0002_rename_code_to_code_hash.py
+++ b/backend/apps/sms/migrations/0002_rename_code_to_code_hash.py
@@ -1,0 +1,29 @@
+"""
+Rename OTPVerification.code to code_hash and update max_length for SHA-256 storage.
+
+Security fix: OTP codes are now hashed before database storage.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("sms", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="otpverification",
+            old_name="code",
+            new_name="code_hash",
+        ),
+        migrations.AlterField(
+            model_name="otpverification",
+            name="code_hash",
+            field=models.CharField(
+                help_text="SHA-256 hash of the OTP code",
+                max_length=64,
+            ),
+        ),
+    ]

--- a/backend/apps/sms/models.py
+++ b/backend/apps/sms/models.py
@@ -39,7 +39,7 @@ class OTPVerification(models.Model):
     )
 
     # OTP details
-    code = models.CharField(max_length=10, help_text="The OTP code")
+    code_hash = models.CharField(max_length=64, help_text="SHA-256 hash of the OTP code")
     purpose = models.CharField(
         max_length=20,
         choices=Purpose.choices,


### PR DESCRIPTION
## Summary
- Replaced the plaintext `code` field on `OTPVerification` with `code_hash`, which stores a SHA-256 hex digest (64 chars)
- OTP codes are now hashed with `hashlib.sha256` before database storage and on verification
- Constant-time comparison via `secrets.compare_digest` is preserved on the hashed values
- Added a Django migration that renames the column and updates `max_length`
- Updated admin, services, and all tests to use the new field

## Test plan
- [x] All 27 existing SMS/OTP tests pass (service tests and API endpoint tests)
- [ ] Verify migration applies cleanly on a real database
- [ ] Manual smoke test: send an OTP, verify it, confirm the database only stores the hash

Closes #73