### PR TITLE
Extract StatusBadge component with consistent color variants

### DIFF
--- a/frontend/src/components/status-badge.tsx
+++ b/frontend/src/components/status-badge.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+type StatusBadgeVariant = 'success' | 'warning' | 'danger' | 'neutral'
+
+const VARIANT_CLASSES: Record<StatusBadgeVariant, string> = {
+  success: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  warning: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+  danger: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  neutral: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+}
+
+interface StatusBadgeProps {
+  variant: StatusBadgeVariant
+  children: ReactNode
+  icon?: ReactNode
+  className?: string
+}
+
+/**
+ * Consistent status badge used across the app for displaying statuses
+ * such as active/inactive, paid/unpaid, success/failure, etc.
+ */
+export function StatusBadge({ variant, children, icon, className }: StatusBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium',
+        VARIANT_CLASSES[variant],
+        className
+      )}
+    >
+      {icon}
+      {children}
+    </span>
+  )
+}

--- a/frontend/src/features/billing/components/invoice-history-card.tsx
+++ b/frontend/src/features/billing/components/invoice-history-card.tsx
@@ -1,4 +1,5 @@
 import type { Invoice } from '@/api/types'
+import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
@@ -59,17 +60,17 @@ export function InvoiceHistoryCard({
                         </span>
                       </td>
                       <td className="py-3">
-                        <span
-                          className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                        <StatusBadge
+                          variant={
                             invoice.status === 'paid'
-                              ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                              ? 'success'
                               : invoice.status === 'open'
-                                ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
-                                : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
-                          }`}
+                                ? 'warning'
+                                : 'neutral'
+                          }
                         >
                           {invoice.status.charAt(0).toUpperCase() + invoice.status.slice(1)}
-                        </span>
+                        </StatusBadge>
                       </td>
                       <td className="py-3 text-right">
                         {new Intl.NumberFormat(undefined, {

--- a/frontend/src/features/billing/components/subscription-card.tsx
+++ b/frontend/src/features/billing/components/subscription-card.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { SubscriptionInfo } from '@/api/types'
+import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { useConfirmSubscription, useCreatePortalSession } from '@/features/billing/api/mutations'
@@ -69,14 +70,14 @@ export function SubscriptionCard({ subscription, memberCount }: SubscriptionCard
               <div>
                 <div className="flex items-center gap-2">
                   <span className="font-medium">Pro Plan</span>
-                  <span
-                    className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                  <StatusBadge
+                    variant={
                       subscription.status === 'active'
-                        ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                        ? 'success'
                         : subscription.status === 'past_due'
-                          ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
-                          : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
-                    }`}
+                          ? 'warning'
+                          : 'neutral'
+                    }
                   >
                     {subscription.status === 'active'
                       ? 'Active'
@@ -85,7 +86,7 @@ export function SubscriptionCard({ subscription, memberCount }: SubscriptionCard
                         : subscription.status === 'trialing'
                           ? 'Trial'
                           : subscription.status}
-                  </span>
+                  </StatusBadge>
                 </div>
                 <p className="text-sm text-muted-foreground mt-1">
                   {subscription.quantity} {subscription.quantity === 1 ? 'seat' : 'seats'}

--- a/frontend/src/features/members/components/members-table.tsx
+++ b/frontend/src/features/members/components/members-table.tsx
@@ -1,4 +1,5 @@
 import type { MemberListItem } from '@/api/types'
+import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import {
@@ -49,13 +50,9 @@ export function MembersTable({ members, onRoleChange, onRemove }: MembersTablePr
                   <td className="p-3 text-muted-foreground">{member.name || '—'}</td>
                   <td className="p-3">
                     {member.status === 'invited' ? (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
-                        Pending
-                      </span>
+                      <StatusBadge variant="warning">Pending</StatusBadge>
                     ) : (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                        Active
-                      </span>
+                      <StatusBadge variant="success">Active</StatusBadge>
                     )}
                   </td>
                   <td className="p-3">

--- a/frontend/src/features/webhooks/components/webhook-deliveries-dialog.tsx
+++ b/frontend/src/features/webhooks/components/webhook-deliveries-dialog.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Check, Clock, RefreshCw } from 'lucide-react'
 import type { WebhookDelivery, WebhookEndpoint } from '@/api/types'
+import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -33,24 +34,21 @@ function getStatusBadge(delivery: WebhookDelivery) {
   switch (delivery.status) {
     case 'success':
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
-          {getStatusIcon(delivery.status)}
+        <StatusBadge variant="success" icon={getStatusIcon(delivery.status)}>
           {delivery.http_status}
-        </span>
+        </StatusBadge>
       )
     case 'failure':
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400">
-          {getStatusIcon(delivery.status)}
+        <StatusBadge variant="danger" icon={getStatusIcon(delivery.status)}>
           {delivery.http_status ? String(delivery.http_status) : delivery.error_type || 'Error'}
-        </span>
+        </StatusBadge>
       )
     case 'pending':
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
-          {getStatusIcon(delivery.status)}
+        <StatusBadge variant="warning" icon={getStatusIcon(delivery.status)}>
           Retry #{delivery.attempt_number}
-        </span>
+        </StatusBadge>
       )
   }
 }

--- a/frontend/src/features/webhooks/components/webhook-endpoints-list.tsx
+++ b/frontend/src/features/webhooks/components/webhook-endpoints-list.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react'
 import { useState } from 'react'
 import type { WebhookEndpoint, WebhookEventType } from '@/api/types'
+import { StatusBadge } from '@/components/status-badge'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -104,41 +105,36 @@ export function WebhookEndpointsList({
   const getStatusBadge = (endpoint: WebhookEndpoint) => {
     if (!endpoint.active) {
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-          <Pause className="h-3 w-3" />
+        <StatusBadge variant="neutral" icon={<Pause className="h-3 w-3" />}>
           Disabled
-        </span>
+        </StatusBadge>
       )
     }
     if (endpoint.consecutive_failures >= 5) {
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400">
-          <AlertTriangle className="h-3 w-3" />
+        <StatusBadge variant="danger" icon={<AlertTriangle className="h-3 w-3" />}>
           Failing
-        </span>
+        </StatusBadge>
       )
     }
     if (endpoint.last_delivery_status === 'success') {
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">
-          <Check className="h-3 w-3" />
+        <StatusBadge variant="success" icon={<Check className="h-3 w-3" />}>
           Active
-        </span>
+        </StatusBadge>
       )
     }
     if (endpoint.last_delivery_status === 'failure') {
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400">
-          <AlertTriangle className="h-3 w-3" />
+        <StatusBadge variant="warning" icon={<AlertTriangle className="h-3 w-3" />}>
           Warning
-        </span>
+        </StatusBadge>
       )
     }
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-        <Clock className="h-3 w-3" />
+      <StatusBadge variant="neutral" icon={<Clock className="h-3 w-3" />}>
         No deliveries
-      </span>
+      </StatusBadge>
     )
   }
 


### PR DESCRIPTION
## Summary
- Extracted a reusable `StatusBadge` component (`frontend/src/components/status-badge.tsx`) with `variant` prop accepting `success`, `warning`, `danger`, and `neutral`
- Standardized Tailwind color classes with consistent dark mode support across all variants
- Replaced ~15 inline badge instances across 5 components with the new `StatusBadge` component

## Changed files
- **New:** `frontend/src/components/status-badge.tsx` — shared StatusBadge component
- **Updated:** `frontend/src/features/members/components/members-table.tsx`
- **Updated:** `frontend/src/features/billing/components/subscription-card.tsx`
- **Updated:** `frontend/src/features/billing/components/invoice-history-card.tsx`
- **Updated:** `frontend/src/features/webhooks/components/webhook-endpoints-list.tsx`
- **Updated:** `frontend/src/features/webhooks/components/webhook-deliveries-dialog.tsx`

## Test plan
- [ ] Verify members table shows "Active" (green) and "Pending" (amber) badges correctly
- [ ] Verify subscription card shows correct badge for active, past_due, trialing, and other statuses
- [ ] Verify invoice history shows correct badge for paid, open, and other statuses
- [ ] Verify webhook endpoints list shows all 5 badge states (Disabled, Failing, Active, Warning, No deliveries) with correct icons
- [ ] Verify webhook deliveries dialog shows success, failure, and pending badges with correct icons
- [ ] Verify all badges render correctly in dark mode

Closes #79