### PR TITLE
Extract useConfirmDialog hook and ConfirmDialog component

### DIFF
--- a/frontend/src/components/confirm-dialog.tsx
+++ b/frontend/src/components/confirm-dialog.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  title: string
+  description: ReactNode
+  confirmLabel?: string
+  variant?: 'destructive' | 'default'
+  disabled?: boolean
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  variant = 'default',
+  disabled,
+}: ConfirmDialogProps) {
+  const destructiveClassName =
+    variant === 'destructive'
+      ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+      : undefined
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className={destructiveClassName}
+            disabled={disabled}
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/features/webhooks/components/webhook-endpoints-list.tsx
+++ b/frontend/src/features/webhooks/components/webhook-endpoints-list.tsx
@@ -11,9 +11,9 @@ import {
 } from 'lucide-react'
 import { useState } from 'react'
 import type { WebhookEndpoint, WebhookEventType } from '@/api/types'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -35,6 +35,7 @@ import {
   useTestWebhookEndpoint,
   useUpdateWebhookEndpoint,
 } from '@/features/webhooks/api/mutations'
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog'
 
 interface WebhookEndpointsListProps {
   endpoints: WebhookEndpoint[]
@@ -56,8 +57,12 @@ export function WebhookEndpointsList({
   const deleteMutation = useDeleteWebhookEndpoint()
   const testMutation = useTestWebhookEndpoint()
 
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [endpointToDelete, setEndpointToDelete] = useState<WebhookEndpoint | null>(null)
+  const deleteDialog = useConfirmDialog<WebhookEndpoint>((endpoint) => {
+    deleteMutation.mutate(endpoint.id, {
+      onSettled: () => deleteDialog.reset(),
+    })
+  })
+
   const [testDialogOpen, setTestDialogOpen] = useState(false)
   const [endpointToTest, setEndpointToTest] = useState<WebhookEndpoint | null>(null)
 
@@ -65,21 +70,6 @@ export function WebhookEndpointsList({
     updateMutation.mutate({
       endpointId: endpoint.id,
       data: { active: !endpoint.active },
-    })
-  }
-
-  const openDeleteDialog = (endpoint: WebhookEndpoint) => {
-    setEndpointToDelete(endpoint)
-    setDeleteDialogOpen(true)
-  }
-
-  const handleDeleteConfirm = () => {
-    if (!endpointToDelete) return
-    deleteMutation.mutate(endpointToDelete.id, {
-      onSettled: () => {
-        setDeleteDialogOpen(false)
-        setEndpointToDelete(null)
-      },
     })
   }
 
@@ -257,7 +247,7 @@ export function WebhookEndpointsList({
                           <DropdownMenuSeparator />
                           <DropdownMenuItem
                             onClick={() => {
-                              openDeleteDialog(endpoint)
+                              deleteDialog.openDialog(endpoint)
                             }}
                             className="text-destructive focus:text-destructive"
                           >
@@ -276,26 +266,20 @@ export function WebhookEndpointsList({
       </Card>
 
       {/* Delete Confirmation Dialog */}
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete webhook endpoint</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete <strong>{endpointToDelete?.name}</strong>? This action
-              cannot be undone and all delivery history will be lost.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        open={deleteDialog.open}
+        onOpenChange={deleteDialog.onOpenChange}
+        onConfirm={deleteDialog.onConfirm}
+        title="Delete webhook endpoint"
+        description={
+          <>
+            Are you sure you want to delete <strong>{deleteDialog.item?.name}</strong>? This action
+            cannot be undone and all delivery history will be lost.
+          </>
+        }
+        confirmLabel="Delete"
+        variant="destructive"
+      />
 
       {/* Test Event Dialog */}
       <AlertDialog open={testDialogOpen} onOpenChange={setTestDialogOpen}>

--- a/frontend/src/hooks/use-confirm-dialog.ts
+++ b/frontend/src/hooks/use-confirm-dialog.ts
@@ -1,0 +1,54 @@
+import { useCallback, useState } from 'react'
+
+interface UseConfirmDialogReturn<T> {
+  open: boolean
+  item: T | null
+  openDialog: (item: T) => void
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  reset: () => void
+}
+
+/**
+ * Manages open/item/confirm state for confirmation dialogs.
+ *
+ * @param onConfirm - Called with the current item when the user confirms.
+ */
+export function useConfirmDialog<T>(onConfirm: (item: T) => void): UseConfirmDialogReturn<T> {
+  const [open, setOpen] = useState(false)
+  const [item, setItem] = useState<T | null>(null)
+
+  const openDialog = useCallback((target: T) => {
+    setItem(target)
+    setOpen(true)
+  }, [])
+
+  const reset = useCallback(() => {
+    setOpen(false)
+    setItem(null)
+  }, [])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        reset()
+      }
+    },
+    [reset]
+  )
+
+  const handleConfirm = useCallback(() => {
+    if (item !== null) {
+      onConfirm(item)
+    }
+  }, [item, onConfirm])
+
+  return {
+    open,
+    item,
+    openDialog,
+    onOpenChange: handleOpenChange,
+    onConfirm: handleConfirm,
+    reset,
+  }
+}

--- a/frontend/src/pages/settings/members-settings.tsx
+++ b/frontend/src/pages/settings/members-settings.tsx
@@ -1,16 +1,7 @@
 import { Users } from 'lucide-react'
 import { useState } from 'react'
 import type { DirectoryUser } from '@/api/types'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { EmailAutocomplete } from '@/components/ui/email-autocomplete'
@@ -31,6 +22,7 @@ import {
 import { useMembers } from '@/features/members/api/queries'
 import { BulkInviteDialog } from '@/features/members/components/bulk-invite-dialog'
 import { MembersTable } from '@/features/members/components/members-table'
+import { useConfirmDialog } from '@/hooks/use-confirm-dialog'
 
 export default function MembersSettings() {
   const { data: membersData, isLoading, error } = useMembers()
@@ -47,12 +39,12 @@ export default function MembersSettings() {
   // Bulk invite dialog state
   const [bulkInviteOpen, setBulkInviteOpen] = useState(false)
 
-  // Delete confirmation dialog state
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [memberToDelete, setMemberToDelete] = useState<{
-    id: number
-    email: string
-  } | null>(null)
+  // Delete confirmation dialog
+  const deleteDialog = useConfirmDialog<{ id: number; email: string }>((member) => {
+    deleteMutation.mutate(member.id, {
+      onSettled: () => deleteDialog.reset(),
+    })
+  })
 
   const members = membersData?.members ?? []
 
@@ -106,19 +98,7 @@ export default function MembersSettings() {
   }
 
   const openDeleteDialog = (memberId: number, email: string) => {
-    setMemberToDelete({ id: memberId, email })
-    setDeleteDialogOpen(true)
-  }
-
-  const handleDeleteConfirm = () => {
-    if (!memberToDelete) return
-
-    deleteMutation.mutate(memberToDelete.id, {
-      onSettled: () => {
-        setDeleteDialogOpen(false)
-        setMemberToDelete(null)
-      },
-    })
+    deleteDialog.openDialog({ id: memberId, email })
   }
 
   if (isLoading) {
@@ -221,26 +201,20 @@ export default function MembersSettings() {
       <MembersTable members={members} onRoleChange={handleRoleChange} onRemove={openDeleteDialog} />
 
       {/* Delete Confirmation Dialog */}
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Remove member</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to remove <strong>{memberToDelete?.email}</strong> from this
-              organization? They will lose access immediately.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Remove
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        open={deleteDialog.open}
+        onOpenChange={deleteDialog.onOpenChange}
+        onConfirm={deleteDialog.onConfirm}
+        title="Remove member"
+        description={
+          <>
+            Are you sure you want to remove <strong>{deleteDialog.item?.email}</strong> from this
+            organization? They will lose access immediately.
+          </>
+        }
+        confirmLabel="Remove"
+        variant="destructive"
+      />
 
       {/* Bulk Invite Dialog */}
       <BulkInviteDialog


### PR DESCRIPTION
## Summary
- Extracted a generic `useConfirmDialog<T>()` hook (`frontend/src/hooks/use-confirm-dialog.ts`) that encapsulates open/item/confirm/reset state management for confirmation dialogs
- Created a reusable `ConfirmDialog` component (`frontend/src/components/confirm-dialog.tsx`) that wraps AlertDialog with `title`, `description`, `confirmLabel`, `variant`, `disabled`, `open`, `onOpenChange`, and `onConfirm` props
- Replaced the duplicated confirmation dialog pattern (~40 lines of boilerplate each) in three components: `members-settings.tsx`, `webhook-endpoints-list.tsx`, and `device-list.tsx`

Closes #80

## Test plan
- [ ] Verify member removal confirmation dialog in Settings > Members works correctly (open, cancel, confirm)
- [ ] Verify webhook endpoint deletion confirmation dialog works correctly
- [ ] Verify device removal confirmation dialog works correctly, including the pending/disabled state while removing
- [ ] Verify that dismissing dialogs (clicking Cancel or clicking outside) properly resets state
- [ ] Run `pnpm run type-check` -- passes
- [ ] Run `pnpm run lint` -- no new warnings