### PR TITLE
fix: narrow member search exception to StytchError

### DIFF
--- a/backend/apps/accounts/api.py
+++ b/backend/apps/accounts/api.py
@@ -923,8 +923,8 @@ def list_members(
         # Extract pagination metadata from Stytch response
         total = getattr(search_result, "total_count", 0) or 0
         next_cursor = getattr(search_result, "next_cursor", None) or None
-    except Exception:
-        logger.warning("stytch_member_search_failed", org_id=org.id)
+    except StytchError:
+        logger.warning("stytch_member_search_failed", org_id=org.id, exc_info=True)
 
     # Build a lookup of Stytch member statuses
     stytch_statuses: dict[str, str] = {m["member_id"]: m["status"] for m in stytch_members_data}

--- a/backend/tests/accounts/test_api.py
+++ b/backend/tests/accounts/test_api.py
@@ -1243,7 +1243,16 @@ class TestListMembers:
         MemberFactory.create(user=member_user, organization=org, role="member")
 
         mock_client = MagicMock()
-        mock_client.organizations.members.search.side_effect = Exception("Stytch unavailable")
+        from stytch.core.response_base import StytchError, StytchErrorDetails
+
+        mock_client.organizations.members.search.side_effect = StytchError(
+            StytchErrorDetails(
+                error_type="connection_error",
+                error_message="Stytch unavailable",
+                status_code=503,
+                request_id="req-fallback",
+            )
+        )
 
         request = request_factory.get("/api/v1/auth/organization/members")
         request = make_request_with_auth(  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- Change `except Exception` to `except StytchError` in `list_members` Stytch search
- Add `exc_info=True` to the warning log for better debugging
- Update fallback test to use `StytchError` instead of generic `Exception`

Found during post-merge review of PR #132. The broad catch clause masked programming errors (AttributeError, KeyError) by silently falling back to local DB instead of propagating them.

## Test plan
- [x] `test_stytch_failure_falls_back_to_local_db` updated and passes
- [x] All 63 account API tests pass