### PR TITLE
feat: add ECS deployment circuit breaker

### DIFF
--- a/infra/stacks/app_stack.py
+++ b/infra/stacks/app_stack.py
@@ -437,6 +437,7 @@ class AppStack(Stack):
                 health_check_grace_period=Duration.seconds(120),
                 min_healthy_percent=100,
                 max_healthy_percent=200,
+                circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True),
             )
 
             # Enable ECS Exec
@@ -503,6 +504,7 @@ class AppStack(Stack):
                 health_check_grace_period=Duration.seconds(120),
                 min_healthy_percent=100,
                 max_healthy_percent=200,
+                circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True),
             )
 
             # Enable ECS Exec for debugging and running migrations


### PR DESCRIPTION
## Summary
- Enables the ECS deployment circuit breaker with automatic rollback on both shared-mode and standalone-mode Fargate services
- If new tasks repeatedly fail to stabilize during a deployment, ECS will automatically roll back to the last stable deployment instead of leaving the service in a degraded state

## Context
The project already has health checks, rolling deployment controls (`min_healthy_percent=100`, `max_healthy_percent=200`), and CloudWatch alarms — but no mechanism to **automatically stop and revert** a bad deployment. Without the circuit breaker, a deployment where tasks keep crashing can eventually replace all healthy tasks, requiring manual intervention to recover.

## How it works
ECS tracks the number of tasks that fail to reach a steady state. If failures exceed a threshold (calculated based on desired count, with a minimum of 10 checks), the deployment is marked as failed and ECS automatically rolls back to the previous task definition revision.

## Test plan
- [ ] Verify `cdk synth` succeeds (confirmed locally)
- [ ] Verify the `DeploymentCircuitBreaker` appears in the synthesized CloudFormation template for both ECS services
- [ ] Deploy to a staging environment and confirm the service deploys normally
- [ ] Optionally test rollback by deploying a broken image and verifying ECS reverts automatically